### PR TITLE
revert bulletproofs patch to match upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "bulletproofs-og"
 version = "3.0.0-pre.1"
-source = "git+https://github.com/ryankurte/bulletproofs.git?branch=fix/curve25519-backend#e0870eb94e655ddafbeabf1cf72de873efe04411"
+source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e#65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e"
 dependencies = [
  "byteorder",
  "clear_on_drop",
@@ -293,6 +293,8 @@ dependencies = [
  "digest 0.10.6",
  "merlin",
  "rand_core 0.6.4",
+ "serde",
+ "serde_derive",
  "sha3",
  "subtle 2.4.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,7 @@ ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.g
 x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "c1966b8743d320cd07a54191475e5c0f94b2ea30" }
 
 # Fork and rename to use "OG" dalek-cryptography with latest dependencies.
-#bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e" }
-bulletproofs-og = { git = "https://github.com/ryankurte/bulletproofs.git", branch = "fix/curve25519-backend" }
+bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e" }
 
 # Fork and rename to use "OG" dalek-cryptography.
 schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }


### PR DESCRIPTION
since we've dropped bulletproofs as a firmware dependency we don't need the target fix or patch (which no longer exists)...