### PR TITLE
ledger transport refactor

### DIFF
--- a/apdu/src/app_info.rs
+++ b/apdu/src/app_info.rs
@@ -4,21 +4,21 @@
 
 use encdec::{Decode, DecodeOwned, Encode};
 
-use super::{ApduError, ApduStatic, Instruction};
+use super::{ApduError, ApduStatic, Instruction, MOB_APDU_CLA};
 
 /// Fetch application info APDU
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
-pub struct AppInfoReq<const CLA: u8 = 0x00> {}
+pub struct AppInfoReq {}
 
-impl<const CLA: u8> ApduStatic for AppInfoReq<CLA> {
+impl ApduStatic for AppInfoReq {
     /// Application Info command APDU is class `0xb0`
-    const CLA: u8 = 0xb0;
+    const CLA: u8 = MOB_APDU_CLA;
 
     /// Application Info GET APDU is instruction `0x00`
     const INS: u8 = Instruction::GetAppInfo as u8;
 }
 
-impl<const CLA: u8> Encode for AppInfoReq<CLA> {
+impl Encode for AppInfoReq {
     type Error = ApduError;
 
     fn encode_len(&self) -> Result<usize, Self::Error> {
@@ -30,7 +30,7 @@ impl<const CLA: u8> Encode for AppInfoReq<CLA> {
     }
 }
 
-impl<const CLA: u8> DecodeOwned for AppInfoReq<CLA> {
+impl DecodeOwned for AppInfoReq {
     type Output = Self;
 
     type Error = ApduError;
@@ -239,7 +239,7 @@ mod test {
 
     #[test]
     fn app_info_req_apdu() {
-        let apdu = AppInfoReq::<0x12>::default();
+        let apdu = AppInfoReq::default();
 
         let mut buff = [0u8; 128];
         encode_decode_apdu(&mut buff, &apdu);

--- a/fw/.cargo/config.toml
+++ b/fw/.cargo/config.toml
@@ -1,9 +1,9 @@
 
 [target.nanosplus]
-runner = "speculos.py --model nanosp --display qt -a 1 --apdu-port 1237"
+runner = "speculos.py --model nanosp --display qt -a 1 --apdu-port 1237 --zoom 2"
 
 [target.nanox]
-runner = "speculos.py --model nanox --display qt -a 1 --apdu-port 1237"
+runner = "speculos.py --model nanox --display qt -a 1 --apdu-port 1237 --zoom 2"
 
 [build]
 target = "nanosplus"

--- a/fw/src/consts.rs
+++ b/fw/src/consts.rs
@@ -13,14 +13,14 @@ use ledger_mob_core::apdu::app_info::AppFlags;
 pub const APP_NAME: &str = env!("CARGO_PKG_NAME");
 pub const APP_VERSION: &str = env!("GIT_TAG");
 pub const BUILD_TIME: &str = env!("BUILD_TIME");
-pub const APP_FLAGS: AppFlags = app_flags();
 
-const fn app_flags() -> AppFlags {
+pub fn app_flags() -> AppFlags {
+    let mut f = AppFlags::empty();
+
     #[cfg(feature = "summary")]
-    return AppFlags::HAS_TX_SUMMARY;
+    f.set(AppFlags::HAS_TX_SUMMARY, true);
 
-    #[cfg(not(feature = "summary"))]
-    return AppFlags::empty();
+    f
 }
 
 /// Application timeout (exit after no user input)

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -21,7 +21,7 @@ use nanos_sdk::{
 use nanos_ui::layout::{Layout, Location, StringPlace};
 
 use ledger_mob_core::{
-    apdu,
+    apdu::{self, app_info::AppFlags},
     engine::{Engine, Error, Event, State},
 };
 
@@ -225,13 +225,11 @@ fn handle_apdu<RNG: RngCore + CryptoRng>(
     }
 
     // Handle generic commands
-    if i == app_info::AppInfoReq::<10>::INS {
-        let i = app_info::AppInfoResp::new(
-            MOB_PROTO_VERSION,
-            APP_NAME,
-            APP_VERSION,
-            app_info::AppFlags::empty(),
-        );
+    if i == app_info::AppInfoReq::INS {
+        let mut flags = app_flags();
+        flags.set(AppFlags::UNLOCKED, engine.is_unlocked());
+
+        let i = app_info::AppInfoResp::new(MOB_PROTO_VERSION, APP_NAME, APP_VERSION, flags);
 
         match i.encode(&mut comm.apdu_buffer) {
             Ok(n) => {

--- a/fw/src/ui/menu.rs
+++ b/fw/src/ui/menu.rs
@@ -20,7 +20,7 @@ use ledger_mob_core::{
 };
 
 use super::{clear_screen, helpers::*, UiResult};
-use crate::consts::{APP_FLAGS, APP_VERSION, BUILD_TIME, MOB32X32};
+use crate::consts::{app_flags, APP_VERSION, BUILD_TIME, MOB32X32};
 
 #[derive(Copy, Clone, Debug, PartialEq, EnumCount)]
 pub enum MenuState {
@@ -126,7 +126,7 @@ impl UiMenu {
                 let state = engine.state();
                 let s = u16::from_be_bytes([state.state() as u8, state.value() as u8]);
 
-                let mut flags = APP_FLAGS;
+                let mut flags = app_flags();
 
                 if engine.is_unlocked() {
                     flags |= AppFlags::UNLOCKED;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -8,7 +8,8 @@
 // #![feature(async_fn_in_trait)]
 
 use async_trait::async_trait;
-use std::{convert::Infallible, fmt::Debug};
+use std::{convert::Infallible, fmt::Debug, net::SocketAddr};
+use transport::GenericError;
 
 pub use ledger_transport::Exchange;
 
@@ -16,13 +17,7 @@ pub use ledger_transport::Exchange;
 use hidapi::{HidApi, HidError};
 
 /// Re-export transports for consumer use
-pub mod transport {
-    #[cfg(feature = "transport_hid")]
-    pub use ledger_transport_hid::TransportNativeHID;
-
-    #[cfg(feature = "transport_tcp")]
-    pub use ledger_transport_tcp::{TcpOptions, TransportTcp};
-}
+pub mod transport;
 use transport::*;
 
 /// Re-export `ledger-mob-apdu` for consumers
@@ -47,6 +42,27 @@ lazy_static::lazy_static! {
 /// Ledger provider manages ledger devices and connections
 pub struct LedgerProvider {}
 
+/// Device discovery filter
+#[derive(Clone, Debug, PartialEq, clap::ValueEnum, strum::Display)]
+#[non_exhaustive]
+pub enum Filter {
+    /// List all devices available using supported transport
+    Any,
+    /// List only HID devices
+    Hid,
+    /// List only TCP devices
+    Tcp,
+}
+
+/// Ledger device information for listing, used by connect
+#[derive(Debug)]
+pub enum LedgerInfo {
+    #[cfg(feature = "transport_hid")]
+    Hid(hidapi::DeviceInfo),
+    #[cfg(feature = "transport_tcp")]
+    Tcp(TcpOptions),
+}
+
 impl LedgerProvider {
     /// Create a new ledger provider
     pub fn new() -> Result<Self, Error<Infallible>> {
@@ -61,19 +77,72 @@ impl LedgerProvider {
     }
 
     /// List available ledger devices
-    #[cfg(feature = "transport_hid")]
-    pub fn list_devices(&self) -> impl Iterator<Item = hidapi::DeviceInfo> {
-        let hid_api = match &*HIDAPI {
-            Ok(v) => v,
-            Err(_e) => panic!("Invalid HIDAPI state"),
-        };
+    pub async fn list_devices(&self, filter: Filter) -> Vec<LedgerInfo> {
+        let mut devices = vec![];
 
-        // Scan for devices
-        let devices: Vec<_> = TransportNativeHID::list_ledgers(hid_api).cloned().collect();
+        #[cfg(feature = "transport_hid")]
+        if filter == Filter::Any || filter == Filter::Hid {
+            let hid_api = match &*HIDAPI {
+                Ok(v) => v,
+                Err(_e) => panic!("Invalid HIDAPI state"),
+            };
 
-        log::debug!("Found devices: {:?}", devices);
+            TransportNativeHID::list_ledgers(hid_api)
+                .cloned()
+                .for_each(|d| {
+                    devices.push(LedgerInfo::Hid(d));
+                });
+        }
 
-        devices.into_iter()
+        #[cfg(feature = "transport_tcp")]
+        if filter == Filter::Any || filter == Filter::Tcp {
+            // Try connecting to default speculos port
+            let o = TcpOptions::default();
+            if let Ok(_t) = tokio::net::TcpStream::connect(SocketAddr::new(o.addr, o.port)).await {
+                // Return default port if connection succeeded
+                devices.push(LedgerInfo::Tcp(o));
+            };
+        }
+
+        log::debug!("Found {} devices: {:?}", devices.len(), devices);
+
+        devices
+    }
+}
+
+/// Generic ledger device handle (abstract over transport types)
+pub type GenericHandle = DeviceHandle<GenericTransport>;
+
+impl GenericHandle {
+    /// Create a new generic device handle
+    pub fn new(d: impl Into<GenericTransport>) -> Self {
+        Self::from(d.into())
+    }
+}
+
+impl std::fmt::Display for LedgerInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            #[cfg(feature = "transport_hid")]
+            LedgerInfo::Hid(hid_info) => {
+                write!(
+                    f,
+                    "{:16} (USB, {:04x}:{:04x}, {})",
+                    hid_info.product_string().unwrap_or("UNKNOWN"),
+                    hid_info.vendor_id(),
+                    hid_info.product_id(),
+                    hid_info.serial_number().unwrap_or("UNKNOWN"),
+                )
+            }
+            #[cfg(feature = "transport_tcp")]
+            LedgerInfo::Tcp(tcp_info) => {
+                write!(
+                    f,
+                    "{:16} (TCP, {}:{})",
+                    "Speculos", tcp_info.addr, tcp_info.port
+                )
+            }
+        }
     }
 }
 
@@ -82,10 +151,47 @@ impl LedgerProvider {
 pub trait Connect<T: Exchange> {
     type Options: Debug;
 
+    /// Connect to the specified device
     async fn connect(
         &self,
         opts: &Self::Options,
     ) -> Result<DeviceHandle<T>, Error<<T as Exchange>::Error>>;
+}
+
+/// Generic connect implementation
+#[async_trait]
+impl Connect<GenericTransport> for LedgerProvider {
+    type Options = LedgerInfo;
+
+    async fn connect(
+        &self,
+        opts: &Self::Options,
+    ) -> Result<DeviceHandle<GenericTransport>, Error<GenericError>> {
+        let t = match opts {
+            #[cfg(feature = "transport_hid")]
+            LedgerInfo::Hid(hid_info) => {
+                let hid_api = match &*HIDAPI {
+                    Ok(v) => v,
+                    Err(_e) => return Err(Error::HidInit),
+                };
+
+                // Connect to device
+                let t = TransportNativeHID::open_device(hid_api, hid_info)?;
+
+                // Create handle
+                GenericTransport::Hid(t)
+            }
+            #[cfg(feature = "transport_tcp")]
+            LedgerInfo::Tcp(tcp_info) => {
+                // Connect to device
+                let t = TransportTcp::new(tcp_info.clone()).await?;
+
+                GenericTransport::Tcp(t)
+            }
+        };
+
+        Ok(DeviceHandle::from(t))
+    }
 }
 
 /// Connect implementation for HID devices
@@ -97,8 +203,7 @@ impl Connect<TransportNativeHID> for LedgerProvider {
     async fn connect(
         &self,
         opts: &Self::Options,
-    ) -> Result<DeviceHandle<TransportNativeHID>, Error<<TransportNativeHID as Exchange>::Error>>
-    {
+    ) -> Result<DeviceHandle<TransportNativeHID>, TransportHidError> {
         let hid_api = match &*HIDAPI {
             Ok(v) => v,
             Err(_e) => return Err(Error::HidInit),
@@ -123,7 +228,7 @@ impl Connect<TransportTcp> for LedgerProvider {
     async fn connect(
         &self,
         opts: &Self::Options,
-    ) -> Result<DeviceHandle<TransportTcp>, Error<<TransportTcp as Exchange>::Error>> {
+    ) -> Result<DeviceHandle<TransportTcp>, TransportTcpError> {
         // Connect to device
         let t = TransportTcp::new(opts.clone())
             .await

--- a/lib/src/transport.rs
+++ b/lib/src/transport.rs
@@ -11,6 +11,7 @@ pub use ledger_transport_hid::TransportNativeHID;
 
 #[cfg(feature = "transport_tcp")]
 pub use ledger_transport_tcp::{TcpOptions, TransportTcp};
+use strum::Display;
 
 use crate::Error;
 
@@ -23,6 +24,8 @@ pub type TransportHidError = Error<ledger_transport_hid::LedgerHIDError>;
 pub type TransportTcpError = Error<ledger_transport_tcp::Error>;
 
 /// Generic ledger device (abstract over transport types)
+#[derive(Display)]
+#[non_exhaustive]
 pub enum GenericTransport {
     #[cfg(feature = "transport_hid")]
     Hid(TransportNativeHID),
@@ -32,6 +35,7 @@ pub enum GenericTransport {
 
 /// Generic transport error
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum GenericError {
     #[cfg(feature = "transport_hid")]
     #[error("HID transport error: {0}")]
@@ -73,6 +77,8 @@ impl Exchange for GenericTransport {
             Self::Hid(t) => t.exchange(req, buff).await?,
             #[cfg(feature = "transport_tcp")]
             Self::Tcp(t) => t.exchange(req, buff).await?,
+            #[cfg(not(all(feature = "transport_hid", feature = "transport_tcp")))]
+            _ => panic!("Transport {} unavailable", self),
         };
 
         Ok(r)

--- a/lib/src/transport.rs
+++ b/lib/src/transport.rs
@@ -1,0 +1,94 @@
+//! Generic transport abstraction for hiding underlying transport types
+//!
+// Copyright (c) 2022-2023 The MobileCoin Foundation
+
+use async_trait::async_trait;
+use ledger_apdu::{ApduBase, ApduCmd};
+use ledger_transport::Exchange;
+
+#[cfg(feature = "transport_hid")]
+pub use ledger_transport_hid::TransportNativeHID;
+
+#[cfg(feature = "transport_tcp")]
+pub use ledger_transport_tcp::{TcpOptions, TransportTcp};
+
+use crate::Error;
+
+/// Re-export HID transport error type
+#[cfg(feature = "transport_hid")]
+pub type TransportHidError = Error<ledger_transport_hid::LedgerHIDError>;
+
+/// Re-export TCP transport error type
+#[cfg(feature = "transport_tcp")]
+pub type TransportTcpError = Error<ledger_transport_tcp::Error>;
+
+/// Generic ledger device (abstract over transport types)
+pub enum GenericTransport {
+    #[cfg(feature = "transport_hid")]
+    Hid(TransportNativeHID),
+    #[cfg(feature = "transport_tcp")]
+    Tcp(TransportTcp),
+}
+
+/// Generic transport error
+#[derive(Debug, thiserror::Error)]
+pub enum GenericError {
+    #[cfg(feature = "transport_hid")]
+    #[error("HID transport error: {0}")]
+    Hid(#[from] ledger_transport_hid::LedgerHIDError),
+
+    #[cfg(feature = "transport_tcp")]
+    #[error("TCP transport error: {0}")]
+    Tcp(#[from] ledger_transport_tcp::Error),
+}
+
+/// Convert a HID transport into a generic transport
+#[cfg(feature = "transport_hid")]
+impl From<TransportNativeHID> for GenericTransport {
+    fn from(t: TransportNativeHID) -> Self {
+        Self::Hid(t)
+    }
+}
+
+/// Convert a TCP transport into a generic transport
+#[cfg(feature = "transport_tcp")]
+impl From<ledger_transport_tcp::TransportTcp> for GenericTransport {
+    fn from(t: TransportTcp) -> Self {
+        Self::Tcp(t)
+    }
+}
+
+/// Implementation of [Exchange] for [GenericDevice], hiding transport error types
+#[async_trait]
+impl Exchange for GenericTransport {
+    type Error = GenericError;
+
+    async fn exchange<'a, 'c, ANS: ApduBase<'a>>(
+        &self,
+        req: impl ApduCmd<'c>,
+        buff: &'a mut [u8],
+    ) -> Result<ANS, Self::Error> {
+        let r = match self {
+            #[cfg(feature = "transport_hid")]
+            Self::Hid(t) => t.exchange(req, buff).await?,
+            #[cfg(feature = "transport_tcp")]
+            Self::Tcp(t) => t.exchange(req, buff).await?,
+        };
+
+        Ok(r)
+    }
+}
+
+#[cfg(feature = "transport_hid")]
+impl From<ledger_transport_hid::LedgerHIDError> for Error<GenericError> {
+    fn from(e: ledger_transport_hid::LedgerHIDError) -> Self {
+        Error::Transport(e.into())
+    }
+}
+
+#[cfg(feature = "transport_tcp")]
+impl From<ledger_transport_tcp::Error> for Error<GenericError> {
+    fn from(e: ledger_transport_tcp::Error) -> Self {
+        Error::Transport(e.into())
+    }
+}


### PR DESCRIPTION
refactor to support generic transports to simplify the API for consumers

- adds `GenericHandle`, `TransportGeneric`, `LedgerInfo` types generic over underlying transport
- updates `list_devices` to return all devices using filter over available transports
- fixes app info request type, removes old (now unsupported) device info requests