### PR TITLE
WIP: handle unrecognised APDUs / interaction with ledger-live while nanoapp is running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,6 +2375,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-u64-ratio",
  "mc-util-zip-exact",
  "merlin",
  "prost",
@@ -2407,6 +2408,7 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-u64-ratio",
  "mc-util-vec-map",
  "mc-util-zip-exact",
  "prost",
@@ -2539,6 +2541,10 @@ dependencies = [
  "rand 0.8.5",
  "rand_hc 0.3.1",
 ]
+
+[[package]]
+name = "mc-util-u64-ratio"
+version = "4.0.2"
 
 [[package]]
 name = "mc-util-vec-map"

--- a/core/src/engine/function.rs
+++ b/core/src/engine/function.rs
@@ -136,7 +136,7 @@ impl Function {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub fn summarizer_init(
         &mut self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -717,7 +717,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
     #[cfg_attr(feature = "noinline", inline(never))]
     fn tx_summary_init(
         &mut self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: u32,
         num_outputs: u32,
         num_inputs: u32,

--- a/core/src/engine/summary.rs
+++ b/core/src/engine/summary.rs
@@ -48,7 +48,7 @@ pub enum SummaryState {
 impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     /// Create a new summarizer instance
     pub fn new(
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,
@@ -82,7 +82,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub unsafe fn init(
         p: *mut Self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -254,7 +254,7 @@ fn handle_apdu<RNG: RngCore + CryptoRng>(
         return false;
     }
 
-    // Handle generic commands
+    // Handle generic app info request
     if i == app_info::AppInfoReq::INS {
         let mut flags = app_flags();
         flags.set(AppFlags::UNLOCKED, engine.is_unlocked());
@@ -274,6 +274,13 @@ fn handle_apdu<RNG: RngCore + CryptoRng>(
 
         return false;
     }
+
+    // Ignore APDUs for other apps
+    if comm.apdu_buffer[0] != MOB_APDU_CLA {
+        comm.reply(SyscallError::Unspecified);
+        return false;
+    }
+    
 
     // Handle engine / transaction commands
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 
 use ledger_mob_apdu::state::TxState;
-use mc_crypto_ring_signature_signer::{Error as SignerError};
+use mc_crypto_ring_signature_signer::Error as SignerError;
 use tokio::time::error::Elapsed;
 
 /// Ledger MobileCoin API Error Type

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 
 use ledger_mob_apdu::state::TxState;
-use mc_crypto_ring_signature_signer::Error as SignerError;
+use mc_crypto_ring_signature_signer::{Error as SignerError};
 use tokio::time::error::Elapsed;
 
 /// Ledger MobileCoin API Error Type

--- a/lib/src/tx/ring.rs
+++ b/lib/src/tx/ring.rs
@@ -13,7 +13,7 @@ use ledger_transport::Exchange;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_crypto_ring_signature::{CurveScalar, RingMLSAG, Scalar};
 use mc_crypto_ring_signature_signer::{
-    Error as SignerError, OneTimeKeyDeriveData, RingSigner, SignableInputRing,
+    OneTimeKeyDeriveData, RingSigner, SignableInputRing, Error as SignerError,
 };
 
 use ledger_mob_apdu::{state::TxState, tx::*};

--- a/lib/src/tx/ring.rs
+++ b/lib/src/tx/ring.rs
@@ -13,7 +13,7 @@ use ledger_transport::Exchange;
 use mc_crypto_keys::CompressedRistrettoPublic;
 use mc_crypto_ring_signature::{CurveScalar, RingMLSAG, Scalar};
 use mc_crypto_ring_signature_signer::{
-    OneTimeKeyDeriveData, RingSigner, SignableInputRing, Error as SignerError,
+    Error as SignerError, OneTimeKeyDeriveData, RingSigner, SignableInputRing,
 };
 
 use ledger_mob_apdu::{state::TxState, tx::*};


### PR DESCRIPTION
adds support for ledger standard(ish) AppInfo and DeviceInfo APDUs so that ledger live understands when an app is open.

(this is a partial implementation pending some additions to the nanos_sdk, but it solves the app crash when opening ledger live / ledger live shows error when app is open issues)

towards #19 