### PR TITLE
stack use improvements (towards nanox execution)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,11 @@ nanosplus-gdb:
 objdump:
 	arm-none-eabi-objdump fw/target/nanosplus/release/ledger-mob-fw --disassemble=sample_main -S | head -n 20
 
-wts:
-	whatthestack fw/target/nanosplus/release/ledger-mob-fw -n 15
+wts-nanosplus:
+	wts fw/target/nanosplus/release/ledger-mob-fw -n 15
+
+wts-nanox:
+	wts fw/target/nanox/release/ledger-mob-fw -n 15
 
 # Run linters
 lint: fmt clippy

--- a/core/src/engine/event.rs
+++ b/core/src/engine/event.rs
@@ -164,6 +164,7 @@ where
 
 impl<'a> Event<'a> {
     /// Parse an incoming APDU to engine event
+    #[cfg_attr(feature = "noinline", inline(never))]
     pub fn parse(ins: u8, buff: &'a [u8]) -> Result<Self, ApduError> {
         match ins {
             WalletKeyReq::INS => decode_event::<WalletKeyReq>(buff),

--- a/core/src/engine/output.rs
+++ b/core/src/engine/output.rs
@@ -86,7 +86,8 @@ pub enum Output {
 }
 
 impl Output {
-    /// Encode an [`Output`] object to a response [APDU
+    /// Encode an [`Output`] object to a response [APDU]
+    #[cfg_attr(feature = "noinline", inline(never))]
     pub fn encode(&self, buff: &mut [u8]) -> Result<usize, ApduError> {
         match self.clone() {
             Output::None => Ok(0),

--- a/fw/nanox.json
+++ b/fw/nanox.json
@@ -1,7 +1,6 @@
 {
   "abi": "eabi",
   "arch": "arm",
-  "atomic-cas": false,
   "c-enum-min-bits": 8,
   "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
   "emit-debug-gdb-scripts": false,
@@ -10,6 +9,7 @@
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-target": "thumbv7m-none-eabi",
+  "atomic-cas": false,
   "panic-strategy": "abort",
   "pre-link-args": {
       "ld.lld": [
@@ -26,5 +26,4 @@
   "target-pointer-width": "32",
   "os": "nanox",
   "target-family": [ "bolos" ]
-
 }

--- a/fw/nanox.json
+++ b/fw/nanox.json
@@ -9,7 +9,7 @@
   "frame-pointer": "always",
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
-  "llvm-target": "thumbv6m-none-eabi",
+  "llvm-target": "thumbv7m-none-eabi",
   "panic-strategy": "abort",
   "pre-link-args": {
       "ld.lld": [

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -75,8 +75,9 @@ extern "C" fn sample_main() {
 
     // Bind engine context
     let engine = unsafe {
-        ENGINE_CTX.write(Engine::new_with_rng(LedgerDriver {}, LedgerRng {}));
-        &mut *ENGINE_CTX.as_mut_ptr()
+        let p = &mut *ENGINE_CTX.as_mut_ptr();
+        Engine::init(p, LedgerDriver {}, LedgerRng {});
+        p
     };
 
     // Developer mode / pending review popup
@@ -145,7 +146,7 @@ extern "C" fn sample_main() {
 }
 
 /// Handle button events, returning true if UI should be redrawn
-#[inline]
+#[cfg_attr(feature = "noinline", inline(never))]
 fn handle_btn<RNG: RngCore + CryptoRng>(
     engine: &mut Engine<LedgerDriver, RNG>,
     _comm: &mut io::Comm,
@@ -232,7 +233,8 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
 }
 
 /// Handle APDU commands, returning true if UI should be redrawn
-#[inline]
+//#[inline]
+#[cfg_attr(feature = "noinline", inline(never))]
 fn handle_apdu<RNG: RngCore + CryptoRng>(
     engine: &mut Engine<LedgerDriver, RNG>,
     comm: &mut io::Comm,
@@ -282,8 +284,7 @@ fn handle_apdu<RNG: RngCore + CryptoRng>(
 
     // WIP: user acknowledgement screens etc.
     // to be moved once i've worked out how to wire this best
-
-    match evt {
+    match &evt {
         Event::GetWalletKeys { .. }
         | Event::GetSubaddressKeys { .. }
         | Event::GetKeyImage { .. }
@@ -381,6 +382,7 @@ fn handle_apdu<RNG: RngCore + CryptoRng>(
 
 const APPROVE_KEY_REQ: &str = "Sync View Keys?";
 
+#[cfg_attr(feature = "noinline", inline(never))]
 fn platform_tests(comm: &mut io::Comm) {
     clear_screen();
 


### PR DESCRIPTION
attempting to fix the app execution on the nanox (no luck so far)

further improvements to stack frame sizes in the hope that the less efficient ISA caused a recurrence of the 8kb of stack issue, blocking inlining of large functions in the same stack frame and swapping to per-field init of large objects. this doesn't _appear_ to have helped.

testing targets for nanosplus/nanox devices to try and isolate the error from the ISA
- build for nanox with `thumbv7m-none-eabi` target (adds `DIV` and `MOD` instructions), this runs correctly in simulator, @yhql tested this still appears to fail on device
- tested compiling for nanosplus with `thumbv7m-none-eabi` and `thumbv6m-none-eabi` targets, both run fine on the physical nanosplus and simulator, suggesting the issue is specific to the nanox OS / hardware

---

stack frames before:
```
 ADDR        SIZE   STACK  NAME                                                          
 0xc0df9a89  132    3488   Function::clear                                               
 0xc0df6559  420    3264   <impl Mul<&RistrettoPoint> for &Scalar>::mul                  
 0xc0de60ad  16436  3192   sample_main                                                   
 0xc0de00d9  4428   3160   Engine<DRV,RNG>::ring_update                                  
 0xc0de14a1  5172   2344   Engine<DRV,RNG>::tx_summary_update                            
 0xc0de3df5  492    2168   Engine<DRV,RNG>::ring_init                                    
 0xc0de2935  5312   1608   Engine<DRV,RNG>::update                                       
 0xc0dfb8f9  904    1176   mc_transaction_types::masked_amount::v2::get_blinding_factors 
 0xc0dfa2a9  768    1176   Hkdf<H,I>::new    
 ``` 
stack frames after:
```
 0xc0deebe5  348   3264   <impl Mul<&RistrettoPoint> for &Scalar>::mul                  
 0xc0df30a5  1140  1944   RingSigner::ring_update                                       
 0xc0de1c31  2320  1448   Summarizer<_>::add_output_unblinding                          
 0xc0de0419  4120  1416   Engine<DRV,RNG>::update                                       
 0xc0de18c1  612   1328   RingSigner::ring_init                                         
 0xc0df51ed  700   1152   mc_transaction_types::masked_amount::v2::get_blinding_factors 
 0xc0df3c49  588   1152   Hkdf<H,I>::new                                                
 0xc0de2541  712   1152   Summarizer<_>::finalize                                       
 0xc0df17b5  4464  1112   Event::parse                                                  
 0xc0de1431  464   1112   Engine<DRV,RNG>::memo_sign 
 ```