### PR TITLE
update to upstream dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -172,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bip32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,7 +188,7 @@ dependencies = [
  "k256",
  "once_cell",
  "pbkdf2",
- "rand_core 0.6.4",
+ "rand_core",
  "ripemd",
  "sha2 0.10.6",
  "subtle",
@@ -278,14 +284,13 @@ dependencies = [
 [[package]]
 name = "bulletproofs-og"
 version = "3.0.0-pre.1"
-source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e#65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e"
+source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=9abfdc054d9ba65f1e185ea1e6eff3947ce879dc#9abfdc054d9ba65f1e185ea1e6eff3947ce879dc"
 dependencies = [
  "byteorder",
  "clear_on_drop",
  "curve25519-dalek",
- "digest 0.10.6",
  "merlin",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "serde_derive",
  "sha3",
@@ -297,12 +302,6 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
-
-[[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
@@ -323,41 +322,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
-name = "camino"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cargo-emit"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1582e1c9e755dd6ad6b224dcffb135d199399a4568d454bd89fe515ca8425695"
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cc"
@@ -453,7 +421,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -466,7 +434,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -514,9 +482,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "core-foundation-sys"
@@ -619,7 +587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -641,7 +609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -655,13 +623,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.2"
-source = "git+https://github.com/mobilecoinfoundation/curve25519-dalek.git?rev=8791722e0273762552c9a056eaccb7df6baf44d7#8791722e0273762552c9a056eaccb7df6baf44d7"
+version = "4.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d928d978dbec61a1167414f5ec534f24bea0d7a0d24dd9b6233d3d8223e585"
 dependencies = [
- "byteorder",
+ "cfg-if",
  "digest 0.10.6",
+ "fiat-crypto",
  "packed_simd_2",
- "rand_core 0.6.4",
+ "platforms",
+ "rand_core",
  "serde",
  "subtle",
  "zeroize",
@@ -691,7 +662,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -708,7 +679,7 @@ checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -742,7 +713,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -756,7 +727,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -767,7 +738,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -778,7 +749,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -798,6 +769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+]
+
+[[package]]
+name = "der"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -849,7 +830,7 @@ checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -864,33 +845,35 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
+ "der 0.6.0",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
+ "pkcs8",
  "serde",
- "signature",
+ "signature 2.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-pre.1"
-source = "git+https://github.com/mobilecoinfoundation/ed25519-dalek.git?rev=4194e36abc75722e6fba7d552e719448fc38c51f#4194e36abc75722e6fba7d552e719448fc38c51f"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798f704d128510932661a3489b08e3f4c934a01d61c5def59ae7b8e48f19665a"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.8.5",
+ "rand_core",
  "serde",
- "serde_bytes",
  "sha2 0.10.6",
+ "signature 2.0.0",
  "zeroize",
 ]
 
@@ -908,12 +891,12 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "der",
+ "der 0.6.0",
  "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -940,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "encdec"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbb02ebc5765ba1cbd19ac8b87c75ff050ef8609a19c04b6c08d9307fa4c18b"
+checksum = "0a4204dad1927e6344e7358b1217a93f014f5a812187fb1226c6b937e9cddde1"
 dependencies = [
  "encdec-base 0.8.2",
  "encdec-macros 0.8.2",
@@ -967,6 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825dce54de7b07af1e5e6fb68321151291cd0fe7b0765aaa12a757c932ae3a1d"
 dependencies = [
  "byteorder",
+ "heapless 0.7.16",
  "num-traits",
  "thiserror",
 ]
@@ -981,7 +965,7 @@ dependencies = [
  "encdec-base 0.6.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -994,7 +978,7 @@ dependencies = [
  "encdec-base 0.8.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1037,15 +1021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "exr"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,23 +1036,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "filetime"
@@ -1185,7 +1157,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1231,17 +1203,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
@@ -1280,19 +1241,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1635,15 +1590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,7 +1694,7 @@ dependencies = [
  "arrayref",
  "bitflags",
  "byteorder",
- "encdec 0.8.2",
+ "encdec 0.8.3",
  "no-std-compat",
  "num_enum",
  "snafu",
@@ -1766,7 +1712,7 @@ dependencies = [
  "clap 4.1.4",
  "curve25519-dalek",
  "ed25519-dalek",
- "encdec 0.6.2",
+ "encdec 0.8.3",
  "futures",
  "hex",
  "hidapi",
@@ -1791,8 +1737,8 @@ dependencies = [
  "once_cell",
  "portpicker",
  "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -1813,20 +1759,19 @@ dependencies = [
  "bitflags",
  "byteorder",
  "curve25519-dalek",
- "encdec 0.8.2",
+ "encdec 0.8.3",
  "heapless 0.8.0",
  "ledger-apdu",
  "log",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-ring-signature",
  "mc-transaction-types",
  "mc-util-from-random",
  "num_enum",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "sha2 0.10.6",
  "simplelog",
  "strum",
@@ -1846,7 +1791,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "emstr",
- "encdec 0.8.2",
+ "encdec 0.8.3",
  "heapless 0.8.0",
  "hkdf",
  "lazy_static",
@@ -1856,7 +1801,6 @@ dependencies = [
  "ledger-transport",
  "log",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -1868,8 +1812,8 @@ dependencies = [
  "mc-util-test-helper",
  "merlin",
  "num_enum",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "sha2 0.10.6",
  "simplelog",
  "slip10_ed25519",
@@ -1916,10 +1860,8 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-test-helper",
  "portpicker",
- "rand 0.7.3",
- "rand 0.8.5",
- "rand_core 0.5.1",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "serde",
  "serde_json",
  "simplelog",
@@ -2047,7 +1989,7 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "mc-account-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2063,7 +2005,7 @@ dependencies = [
  "mc-util-repr-bytes",
  "mc-util-serial",
  "prost",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "subtle",
  "zeroize",
@@ -2071,14 +2013,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-common"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -2089,15 +2031,14 @@ dependencies = [
  "hex_fmt",
  "hostname",
  "lazy_static",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
- "mc-crypto-rand",
+ "mc-rand",
  "mc-util-build-info",
  "mc-util-logger-macros",
  "mc-util-serial",
  "prost",
- "rand_core 0.6.4",
+ "rand_core",
  "sentry",
  "serde",
  "sha3",
@@ -2106,7 +2047,6 @@ dependencies = [
  "slog-async",
  "slog-atomic",
  "slog-envlogger",
- "slog-gelf",
  "slog-json",
  "slog-scope",
  "slog-stdlog",
@@ -2115,14 +2055,13 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
  "hkdf",
  "mc-core-types",
- "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "serde",
@@ -2145,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aead",
  "digest 0.10.6",
@@ -2154,43 +2093,17 @@ dependencies = [
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-oblivious-aes-gcm",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "mc-crypto-dalek"
-version = "4.0.2"
-dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "mc-crypto-dalek-backend-simd",
- "mc-crypto-dalek-backend-u64",
- "x25519-dalek",
-]
-
-[[package]]
-name = "mc-crypto-dalek-backend-simd"
-version = "2.0.0"
-dependencies = [
- "curve25519-dalek",
-]
-
-[[package]]
-name = "mc-crypto-dalek-backend-u64"
-version = "2.0.0"
-dependencies = [
- "curve25519-dalek",
+ "rand_core",
 ]
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
- "mc-crypto-dalek",
  "mc-crypto-digestible-derive",
  "merlin",
  "x25519-dalek",
@@ -2198,25 +2111,25 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
- "signature",
+ "signature 2.0.0",
 ]
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest 0.10.6",
@@ -2225,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64 0.21.0",
  "curve25519-dalek",
@@ -2235,17 +2148,17 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hex_fmt",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-digestible-signature",
  "mc-util-from-random",
  "mc-util-repr-bytes",
- "rand_core 0.6.4",
- "rand_hc 0.3.1",
+ "mc-util-serial",
+ "rand_core",
+ "rand_hc",
  "schnorrkel-og",
  "serde",
  "sha2 0.10.6",
- "signature",
+ "signature 2.0.0",
  "static_assertions",
  "subtle",
  "x25519-dalek",
@@ -2254,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "hmac",
  "mc-crypto-keys",
@@ -2263,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -2272,24 +2185,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-crypto-rand"
-version = "4.0.2"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "ed25519-dalek",
  "mc-account-keys-types",
  "mc-core-types",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -2297,7 +2200,7 @@ dependencies = [
  "mc-util-repr-bytes",
  "mc-util-serial",
  "prost",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "subtle",
  "zeroize",
@@ -2305,20 +2208,19 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "generic-array",
  "hex_fmt",
  "mc-account-keys",
- "mc-crypto-dalek",
  "mc-crypto-keys",
  "mc-crypto-ring-signature",
  "mc-transaction-types",
  "mc-util-serial",
  "prost",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "subtle",
  "zeroize",
@@ -2326,10 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
- "signature",
 ]
 
 [[package]]
@@ -2348,8 +2249,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-rand"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce58f86dffd114bcefd8bcc6043658feec24b1f29be9972924651fe999ecf4a8"
+dependencies = [
+ "cfg-if",
+ "rand",
+ "rand_core",
+]
+
+[[package]]
 name = "mc-transaction-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "aes 0.8.2",
  "bulletproofs-og",
@@ -2364,7 +2276,6 @@ dependencies = [
  "mc-account-keys",
  "mc-common",
  "mc-crypto-box",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -2375,10 +2286,11 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-u64-ratio",
  "mc-util-zip-exact",
  "merlin",
  "prost",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.10.6",
  "subtle",
@@ -2387,7 +2299,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -2395,7 +2307,6 @@ dependencies = [
  "hmac",
  "mc-account-keys",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -2407,11 +2318,12 @@ dependencies = [
  "mc-util-from-random",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-u64-ratio",
  "mc-util-vec-map",
  "mc-util-zip-exact",
  "prost",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "serde",
  "sha2 0.10.6",
  "subtle",
@@ -2420,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-signer"
-version = "4.0.1"
+version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
  "clap 4.1.4",
@@ -2439,7 +2351,7 @@ dependencies = [
  "mc-transaction-summary",
  "mc-util-repr-bytes",
  "mc-util-serial",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "serde_json",
  "subtle",
@@ -2449,12 +2361,11 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-summary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-account-keys",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-ring-signature",
@@ -2469,12 +2380,11 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
  "hkdf",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -2488,30 +2398,30 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
 name = "mc-util-logger-macros"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -2521,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "prost",
  "serde",
@@ -2531,18 +2441,22 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "clap 4.1.4",
  "lazy_static",
  "mc-account-keys",
- "rand 0.8.5",
- "rand_hc 0.3.1",
+ "rand",
+ "rand_hc",
 ]
 
 [[package]]
+name = "mc-util-u64-ratio"
+version = "4.1.0-pre0"
+
+[[package]]
 name = "mc-util-vec-map"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "heapless 0.7.16",
@@ -2550,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "serde",
 ]
@@ -2578,7 +2492,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
 ]
 
@@ -2624,7 +2538,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
 ]
 
 [[package]]
@@ -2690,7 +2604,7 @@ checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2805,7 +2719,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2821,10 +2735,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der 0.7.1",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "png"
@@ -2856,7 +2786,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2874,7 +2804,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "version_check",
 ]
 
@@ -2891,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2918,40 +2848,16 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
+ "syn 1.0.105",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -2961,18 +2867,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2982,16 +2878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3000,16 +2887,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -3018,7 +2896,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3059,7 +2937,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
@@ -3080,15 +2958,6 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -3233,24 +3102,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schnorrkel-og"
 version = "0.11.0-pre.0"
-source = "git+https://github.com/mobilecoinfoundation/schnorrkel.git?rev=5c98ae068ee4652d6df6463b549fbf2d5d132faa#5c98ae068ee4652d6df6463b549fbf2d5d132faa"
+source = "git+https://github.com/mobilecoinfoundation/schnorrkel?rev=b76d8c3a50671b08af0874b25b2543d3302d794d#b76d8c3a50671b08af0874b25b2543d3302d794d"
 dependencies = [
  "arrayref",
  "arrayvec",
+ "cfg-if",
  "curve25519-dalek",
  "merlin",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2 0.10.6",
  "subtle",
  "zeroize",
@@ -3291,7 +3152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.0",
  "generic-array",
  "subtle",
  "zeroize",
@@ -3302,9 +3163,6 @@ name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "sentry"
@@ -3360,7 +3218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b22828bfd118a7b660cf7a155002a494755c0424cebb7061e4743ecde9c7dbc"
 dependencies = [
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "sentry-types",
  "serde",
  "serde_json",
@@ -3404,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360ee3270f7a4a1eee6c667f7d38360b995431598a73b740dfe420da548d9cc9"
 dependencies = [
  "debugid",
- "getrandom 0.2.8",
+ "getrandom",
  "hex",
  "serde",
  "serde_json",
@@ -3421,15 +3279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f2b4817415c6d4210bfe1c7bfcf4801b2d904cb4d0e1a8fdb651013c9e86b8"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3450,7 +3299,7 @@ checksum = "d071a94a3fac4aff69d023a7f411e33f40f3483f8c5190b1953822b6b76d7630"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3505,7 +3354,7 @@ dependencies = [
  "darling 0.13.4",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3517,7 +3366,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3570,7 +3419,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.6",
- "rand_core 0.6.4",
+ "rand_core",
+]
+
+[[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+dependencies = [
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3589,21 +3447,6 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
-]
 
 [[package]]
 name = "slab"
@@ -3667,21 +3510,6 @@ dependencies = [
  "slog-scope",
  "slog-stdlog",
  "slog-term",
-]
-
-[[package]]
-name = "slog-gelf"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b634d825581a7ef6f0600d425e14cdaa7d5a3a4775202d0c90624afd775b738"
-dependencies = [
- "chrono",
- "flate2",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "skeptic",
- "slog",
 ]
 
 [[package]]
@@ -3756,7 +3584,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3782,6 +3610,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der 0.7.1",
 ]
 
 [[package]]
@@ -3821,7 +3659,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -3842,6 +3680,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,7 +3698,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "unicode-xid",
 ]
 
@@ -3868,20 +3717,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
 ]
 
 [[package]]
@@ -3927,7 +3762,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -4009,7 +3844,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "sha2 0.10.6",
  "thiserror",
@@ -4061,7 +3896,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -4143,15 +3978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -4237,7 +4063,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "serde",
 ]
 
@@ -4248,17 +4074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,12 +4082,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4307,7 +4116,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -4341,7 +4150,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4487,10 +4296,10 @@ dependencies = [
 [[package]]
 name = "x25519-dalek"
 version = "2.0.0-pre.2"
-source = "git+https://github.com/mobilecoinfoundation/x25519-dalek.git?rev=c1966b8743d320cd07a54191475e5c0f94b2ea30#c1966b8743d320cd07a54191475e5c0f94b2ea30"
+source = "git+https://github.com/mobilecoinfoundation/x25519-dalek.git?rev=4fbaa3343301c62cfdbc3023c9f485257e6b718a#4fbaa3343301c62cfdbc3023c9f485257e6b718a"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
 ]
 
@@ -4520,6 +4329,11 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.105",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "ed25519-dalek"
+version = "2.0.0-pre.0"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=2931c688eb11341a1145e257bc41d8ecbe36277c#2931c688eb11341a1145e257bc41d8ecbe36277c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ mc-transaction-types = { path = "./vendor/mob/transaction/types" }
 mc-transaction-signer = { path = "./vendor/mob/transaction/signer" }
 mc-transaction-summary = { path = "./vendor/mob/transaction/summary" }
 mc-util-from-random = { path = "./vendor/mob/util/from-random" }
+mc-util-test-helper = { path = "./vendor/mob/util/test-helper" }
 
 #prost = { path = "../prost" }
 #prost-derive = { path = "../prost/prost-derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,25 +26,23 @@ exclude = [
 
 [patch.crates-io]
 
-# Fix issues with recent nightlies, bump curve25519-dalek version
-curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-dalek.git", rev = "8791722e0273762552c9a056eaccb7df6baf44d7" }
-ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
+# TODO: Once this fork's branch is merged, point to the main repo's main branch commit.
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
 
 # Fix issues with recent nightlies, bump curve25519-dalek version
-x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "c1966b8743d320cd07a54191475e5c0f94b2ea30" }
+x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "4fbaa3343301c62cfdbc3023c9f485257e6b718a" }
 
 # Fork and rename to use "OG" dalek-cryptography with latest dependencies.
-bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "65f8af4ca0bc1cb2fd2148c3259a0a76b155ff3e" }
+bulletproofs-og = { git = "https://github.com/mobilecoinfoundation/bulletproofs.git", rev = "9abfdc054d9ba65f1e185ea1e6eff3947ce879dc" }
 
 # Fork and rename to use "OG" dalek-cryptography.
-schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }
+schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel", rev = "b76d8c3a50671b08af0874b25b2543d3302d794d" }
 
 ledger-apdu = { path = "./vendor/rs/ledger-apdu" }
 ledger-transport = { path = "./vendor/rs/ledger-transport" }
 #ledger-zondax-generic = { path = "./vendor/rs/ledger-zondax-generic" }
 
 mc-core = { path = "./vendor/mob/core" }
-mc-crypto-dalek = { path ="./vendor/mob/crypto/dalek" }
 mc-crypto-digestible = { path ="./vendor/mob/crypto/digestible" }
 mc-crypto-hashes = { path ="./vendor/mob/crypto/hashes" }
 mc-crypto-keys = { path ="./vendor/mob/crypto/keys" }

--- a/apdu/Cargo.toml
+++ b/apdu/Cargo.toml
@@ -14,7 +14,6 @@ default-target = "x86_64-unknown-linux-gnu"
 [features]
 alloc = [ "mc-transaction-types/alloc" ]
 default = [
-    "mc-crypto-dalek/default",
     "alloc",
 ]
 
@@ -29,18 +28,17 @@ rand_core = { version = "0.6.4", default_features = false, features = [ "getrand
 strum = { version = "0.24.1", default_features = false, features = [ "derive" ] }
 encdec = { version = "0.8.0", default_features = false }
 
-curve25519-dalek = { version = "4.0.0-pre.2", default_features = false, features = ["nightly"] }
+curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }
 sha2 = { version = "0.10.6", default_features = false }
 
 ledger-apdu = { version = "0.10.0", default_features = false }
 
-mc-core = { version = "4.0.0", default_features = false, features = [ "internals" ] }
-mc-crypto-dalek = { version = "4.0.0", default_features = false }
-mc-crypto-digestible = { version = "4.0.0", default_features = false }
-mc-crypto-keys = { version = "4.0.0", default_features = false }
-mc-crypto-ring-signature = { version = "4.0.0", default_features = false }
-mc-transaction-types = { version = "4.0.0", default_features = false }
-mc-util-from-random = { version = "4.0.0", default_features = false }
+mc-core = { version = "4.1.0-pre0", default_features = false, features = [ "internals" ] }
+mc-crypto-digestible = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-ring-signature = { version = "4.1.0-pre0", default_features = false }
+mc-transaction-types = { version = "4.1.0-pre0", default_features = false }
+mc-util-from-random = { version = "4.1.0-pre0", default_features = false }
 
 
 [dev-dependencies]

--- a/apdu/src/helpers.rs
+++ b/apdu/src/helpers.rs
@@ -151,7 +151,8 @@ pub(crate) mod pt {
 
         d.copy_from_slice(&buff[..32]);
 
-        let c = CompressedRistretto::from_slice(&d);
+        // TODO: propagate error
+        let c = CompressedRistretto::from_slice(&d).unwrap();
         let p = P::from(c);
 
         Ok((p, 32))

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,7 +31,6 @@ std = [
     "ledger-apdu/std",
 ]
 default = [
-    "mc-crypto-dalek/default",
     "mlsag",
     "memo",
     "summary",
@@ -56,28 +55,25 @@ encdec = { version = "0.8.0", default_features = false }
 thiserror = { version = "1.0.38", optional = true }
 emstr = { version = "0.2.0", default_features = false }
 
-x25519-dalek = { version = "2.0.0-pre.2", default_features = false, features = ["nightly"] }
-curve25519-dalek = { version = "4.0.0-pre.2", default_features = false, features = ["nightly"] }
-ed25519-dalek = { version = "2.0.0-pre.1", default_features = false, features = ["nightly"] }
+
+curve25519-dalek = { version = "4.0.0-rc.1", default_features = false, features = [ "zeroize" ] }
+ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
+x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
 merlin = { version = "3.0.0", default_features = false }
 sha2 = { version = "0.10.6", default_features = false }
 
 ledger-apdu = { version = "0.10.0", default_features = false }
 ledger-mob-apdu = { path = "../apdu", default_features = false }
 
-mc-core = { version = "4.0.0", default_features = false, features = [ "internals" ] }
-mc-crypto-dalek = { version = "4.0.0", default_features = false }
-mc-crypto-digestible = { version = "4.0.0", default_features = false }
-mc-crypto-keys = { version = "4.0.0", default_features = false }
-mc-crypto-hashes = { version = "4.0.0", default_features = false }
-
-mc-crypto-ring-signature = { version = "4.0.0", optional = true, default_features = false, features = [ "internals" ] }
-
-mc-crypto-memo-mac = { version = "4.0.0", optional = true, default_features = false }
-
-mc-transaction-types = { version = "4.0.0", default_features = false }
-mc-transaction-summary = { version = "4.0.0", default_features = false, optional = true }
-mc-util-from-random = { version = "4.0.0", default_features = false }
+mc-core = { version = "4.1.0-pre0", default_features = false, features = [ "internals" ] }
+mc-crypto-digestible = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-hashes = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-ring-signature = { version = "4.1.0-pre0", optional = true, default_features = false, features = [ "internals" ] }
+mc-crypto-memo-mac = { version = "4.1.0-pre0", optional = true, default_features = false }
+mc-transaction-types = { version = "4.1.0-pre0", default_features = false }
+mc-transaction-summary = { version = "4.1.0-pre0", default_features = false, optional = true }
+mc-util-from-random = { version = "4.1.0-pre0", default_features = false }
 
 
 # used by bulletproofs-og, no_cc feature required for cross compilation

--- a/core/src/engine/function.rs
+++ b/core/src/engine/function.rs
@@ -136,7 +136,7 @@ impl Function {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub fn summarizer_init(
         &mut self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,

--- a/core/src/engine/ident.rs
+++ b/core/src/engine/ident.rs
@@ -61,23 +61,16 @@ impl Ident {
     }
 
     /// Compute identity challenge signature using the provide private key
-    pub fn compute(&self, private_key: &[u8]) -> Result<Output, Error> {
+    pub fn compute(&self, private_key: &[u8; 32]) -> Result<Output, Error> {
         #[cfg(feature = "log")]
         log::debug!("computing identity proof");
 
         // Convert to public key type
-        let private_key = ed25519_dalek::SecretKey::from_bytes(private_key).unwrap();
-        let public_key = ed25519_dalek::PublicKey::from(&private_key);
-
-        // Sign provided challenge
-        let keys = ed25519_dalek::Keypair {
-            public: public_key,
-            secret: private_key,
-        };
+        let keys = ed25519_dalek::SigningKey::from_bytes(private_key);
         let signature = ed25519_dalek::Signer::sign(&keys, &self.challenge);
 
         Ok(Output::Identity {
-            public_key: keys.public.to_bytes(),
+            public_key: keys.verifying_key().to_bytes(),
             signature: signature.to_bytes(),
         })
     }
@@ -109,7 +102,7 @@ pub(crate) fn derive_bip32(uri: &str, index: u32) -> [u32; 5] {
 
 #[cfg(test)]
 mod test {
-    use ed25519_dalek::{PublicKey, SecretKey};
+    use ed25519_dalek::{SigningKey, VerifyingKey};
 
     use super::derive_bip32;
     use ledger_mob_tests::ident::{Vector, VECTORS};
@@ -139,8 +132,8 @@ mod test {
             let secret_key = slip10_ed25519::derive_ed25519_private_key(&seed, &p);
 
             // Compute public key
-            let secret_key = SecretKey::from_bytes(&secret_key).unwrap();
-            let public_key = PublicKey::from(&secret_key);
+            let secret_key = SigningKey::from_bytes(&secret_key);
+            let public_key = VerifyingKey::from(&secret_key);
 
             // Compare with expectations
             assert_eq!(public_key.as_bytes(), &v.public_key_bytes());

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -717,7 +717,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
     #[cfg_attr(feature = "noinline", inline(never))]
     fn tx_summary_init(
         &mut self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: u32,
         num_outputs: u32,
         num_inputs: u32,

--- a/core/src/engine/ring.rs
+++ b/core/src/engine/ring.rs
@@ -110,7 +110,7 @@ impl RingSigner {
             blindings: None,
             ring_ctx: None,
             fetch_count: 0,
-            responses: [CurveScalar::from(Scalar::zero()); RESP_SIZE],
+            responses: [CurveScalar::from(Scalar::ZERO); RESP_SIZE],
         })
     }
 

--- a/core/src/engine/summary.rs
+++ b/core/src/engine/summary.rs
@@ -48,7 +48,7 @@ pub enum SummaryState {
 impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     /// Create a new summarizer instance
     pub fn new(
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,
@@ -82,7 +82,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub unsafe fn init(
         p: *mut Self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,

--- a/fw/.cargo/config.toml
+++ b/fw/.cargo/config.toml
@@ -9,8 +9,10 @@ runner = "speculos.py --model nanox --display qt -a 1 --apdu-port 1237 --zoom 2"
 target = "nanosplus"
 rustflags = [
     "-Z", "emit-stack-sizes",
-    "-Clink-args=-Map=/tmp/ledger-mob.map",
+    "-C", "link-args=-Map=/tmp/ledger-mob.map",
+    '--cfg=curve25519_dalek_bits="32"'
 ]
+
 
 [unstable]
 build-std = [ "core", "compiler_builtins", "alloc" ]
@@ -18,6 +20,3 @@ build-std = [ "core", "compiler_builtins", "alloc" ]
 [alias]
 br = "build --release"
 stackcheck = "call-stack --bin ledger-mob-fw --target nanosplus sample_main"
-
-[env]
-RUST_TARGET_PATH = { value = "../../vendor/sdk", relative = true }

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -78,6 +78,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bit_field"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +193,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,11 +304,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-pre.2"
-source = "git+https://github.com/mobilecoinfoundation/curve25519-dalek.git?rev=8791722e0273762552c9a056eaccb7df6baf44d7#8791722e0273762552c9a056eaccb7df6baf44d7"
+version = "4.0.0-rc.1"
+source = "git+https://github.com/dalek-cryptography/curve25519-dalek?rev=99c0520aa79401b69fb51d38172cd58c6a256cfb#99c0520aa79401b69fb51d38172cd58c6a256cfb"
 dependencies = [
- "byteorder",
+ "cfg-if",
  "digest",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "rand_core",
  "subtle",
  "zeroize",
@@ -382,6 +397,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,22 +436,25 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "be522bee13fa6d8059f4903a4084aa3bd50725e18150202f0238deb615cd6371"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-pre.1"
-source = "git+https://github.com/mobilecoinfoundation/ed25519-dalek.git?rev=4194e36abc75722e6fba7d552e719448fc38c51f#4194e36abc75722e6fba7d552e719448fc38c51f"
+version = "2.0.0-pre.0"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=2931c688eb11341a1145e257bc41d8ecbe36277c#2931c688eb11341a1145e257bc41d8ecbe36277c"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand_core",
+ "serde",
  "sha2",
+ "signature",
  "zeroize",
 ]
 
@@ -502,6 +530,12 @@ dependencies = [
  "smallvec",
  "threadpool",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "flate2"
@@ -796,7 +830,6 @@ dependencies = [
  "heapless 0.8.0",
  "ledger-apdu",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-ring-signature",
@@ -826,7 +859,6 @@ dependencies = [
  "ledger-apdu",
  "ledger-mob-apdu",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -877,9 +909,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "link-cplusplus"
@@ -917,21 +955,20 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-core"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "generic-array",
  "hkdf",
  "mc-core-types",
- "mc-crypto-dalek",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "sha2",
@@ -949,27 +986,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "mc-crypto-dalek"
-version = "4.0.2"
-dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "mc-crypto-dalek-backend-simd",
- "mc-crypto-dalek-backend-u64",
- "x25519-dalek",
-]
-
-[[package]]
-name = "mc-crypto-dalek-backend-simd"
-version = "2.0.0"
-
-[[package]]
-name = "mc-crypto-dalek-backend-u64"
-version = "2.0.0"
-
-[[package]]
 name = "mc-crypto-digestible"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -982,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -991,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1000,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "blake2",
  "digest",
@@ -1009,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1019,7 +1037,6 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hex_fmt",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-digestible-signature",
  "mc-util-from-random",
@@ -1037,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "hmac",
  "mc-crypto-keys",
@@ -1046,14 +1063,13 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
  "ed25519-dalek",
  "mc-account-keys-types",
  "mc-core-types",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -1066,11 +1082,10 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-summary"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "mc-core",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-keys",
  "mc-crypto-ring-signature",
@@ -1083,12 +1098,11 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "crc",
  "displaydoc",
  "hkdf",
- "mc-crypto-dalek",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
@@ -1101,21 +1115,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "mc-util-vec-map"
-version = "4.0.2"
+version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
  "heapless 0.7.16",
@@ -1123,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.0.2"
+version = "4.1.0-pre0"
 
 [[package]]
 name = "memoffset"
@@ -1262,6 +1276,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1304,22 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "png"
@@ -1309,15 +1349,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -1384,10 +1415,11 @@ checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 [[package]]
 name = "schnorrkel-og"
 version = "0.11.0-pre.0"
-source = "git+https://github.com/mobilecoinfoundation/schnorrkel.git?rev=5c98ae068ee4652d6df6463b549fbf2d5d132faa#5c98ae068ee4652d6df6463b549fbf2d5d132faa"
+source = "git+https://github.com/mobilecoinfoundation/schnorrkel?rev=b76d8c3a50671b08af0874b25b2543d3302d794d#b76d8c3a50671b08af0874b25b2543d3302d794d"
 dependencies = [
  "arrayref",
  "arrayvec",
+ "cfg-if",
  "curve25519-dalek",
  "merlin",
  "rand_core",
@@ -1453,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
  "digest",
 ]
@@ -1495,6 +1527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1742,7 +1784,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "x25519-dalek"
 version = "2.0.0-pre.2"
-source = "git+https://github.com/mobilecoinfoundation/x25519-dalek.git?rev=c1966b8743d320cd07a54191475e5c0f94b2ea30#c1966b8743d320cd07a54191475e5c0f94b2ea30"
+source = "git+https://github.com/mobilecoinfoundation/x25519-dalek.git?rev=4fbaa3343301c62cfdbc3023c9f485257e6b718a#4fbaa3343301c62cfdbc3023c9f485257e6b718a"
 dependencies = [
  "curve25519-dalek",
  "rand_core",

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -48,16 +48,16 @@ hex_fmt = { version = "0.3.0", default_features = false }
 encdec = { version = "0.8.0", default_features = false }
 emstr = { version = "0.2.0", default_features = false }
 
-mc-core = { version = "4.0.0-pre0", default-features = false }
+mc-core = { version = "4.1.0-pre0", default-features = false }
 ledger-mob-core = { path = "../core", default_features = false }
 
-x25519-dalek = { version = "2.0.0-pre.2", default_features = false, features = ["nightly", "u32_backend"] }
-curve25519-dalek = { version = "4.0.0-pre.2", default_features = false, features = ["nightly", "u32_backend"] }
-ed25519-dalek = { version = "2.0.0-pre.1", default_features = false, features = ["nightly", "u32_backend"] }
+curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }
+ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
+x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
 
 
-libc = "*"
-rlibc = "*"
+libc = "0.2.140"
+rlibc = "1.0.0"
 embedded-alloc = { version = "0.5.0", optional = true }
 critical-section = { version = "1.1.1", optional = true }
 
@@ -101,26 +101,20 @@ lto = 'fat'
 
 [patch.crates-io]
 
-# Fix issues with recent nightlies, bump curve25519-dalek version
-curve25519-dalek = { git = "https://github.com/mobilecoinfoundation/curve25519-dalek.git", rev = "8791722e0273762552c9a056eaccb7df6baf44d7" }
-ed25519-dalek = { git = "https://github.com/mobilecoinfoundation/ed25519-dalek.git", rev = "4194e36abc75722e6fba7d552e719448fc38c51f" }
-#curve25519-dalek = { path = "../../dalek/curve25519-dalek" }
-#ed25519-dalek = { path = "../../dalek/ed25519-dalek" }
 
-# Fix issues with recent nightlies, bump curve25519-dalek version
-x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "c1966b8743d320cd07a54191475e5c0f94b2ea30" }
+curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "99c0520aa79401b69fb51d38172cd58c6a256cfb" }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
+x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "4fbaa3343301c62cfdbc3023c9f485257e6b718a" }
 
 # Fork and rename to use "OG" dalek-cryptography.
-schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel.git", rev = "5c98ae068ee4652d6df6463b549fbf2d5d132faa" }
+schnorrkel-og = { git = "https://github.com/mobilecoinfoundation/schnorrkel", rev = "b76d8c3a50671b08af0874b25b2543d3302d794d" }
 
-#embedded-graphics = { path = "../../embedded-graphics" }
-
+# Patch-out all instances of ledger-apdu for consistent APIs
 ledger-apdu = { path = "../vendor/rs/ledger-apdu" }
 
 # Mobilecoin core patches (replicates workspace level)
 
 mc-core = { path = "../vendor/mob/core" }
-mc-crypto-dalek = { path ="../vendor/mob/crypto/dalek" }
 mc-crypto-digestible = { path ="../vendor/mob/crypto/digestible" }
 mc-crypto-hashes = { path ="../vendor/mob/crypto/hashes" }
 mc-crypto-keys = { path ="../vendor/mob/crypto/keys" }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,8 +23,8 @@ async-trait = "0.1.57"
 anyhow = "1.0.58"
 base64 = "0.21.0"
 clap = { version = "4.0.26", features = [ "derive" ] }
-ed25519-dalek = { version = "2.0.0-pre.1", default_features = false, features = ["nightly"] }
-encdec = "*"
+ed25519-dalek = { version = "2.0.0-pre.1", default_features = false }
+encdec = "0.8.3"
 strum = { version = "0.24.1", features = [ "derive" ] }
 tokio = { version = "1.20.1", features = [ "full" ] }
 hex = "0.4.3"
@@ -50,14 +50,14 @@ ledger-transport-hid = { path = "../vendor/rs/ledger-transport-hid", optional = 
 
 ledger-mob-apdu = { path = "../apdu" }
 
-mc-core = { version = "4.0.0", features = [ "serde" ] }
-mc-crypto-keys = { version = "4.0.0", default_features = false }
-mc-crypto-ring-signature = { version = "4.0.0", default_features = false }
-mc-crypto-ring-signature-signer = { version = "4.0.0", default_features = false }
-mc-transaction-core = { version = "4.0.0" }
-mc-transaction-extra = { version = "4.0.0" }
-mc-transaction-signer = { version = "4.0.0" }
-mc-transaction-summary = { version = "4.0.0" }
+mc-core = { version = "4.1.0-pre0", features = [ "serde" ] }
+mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-ring-signature = { version = "4.1.0-pre0", default_features = false }
+mc-crypto-ring-signature-signer = { version = "4.1.0-pre0", default_features = false }
+mc-transaction-core = { version = "4.1.0-pre0" }
+mc-transaction-extra = { version = "4.1.0-pre0" }
+mc-transaction-signer = { version = "4.1.0-pre0" }
+mc-transaction-summary = { version = "4.1.0-pre0" }
 
 
 [dev-dependencies]
@@ -69,14 +69,14 @@ serde = { version = "1.0.144", features = [ "derive" ] }
 ledger-sim = { path = "../sim" }
 ledger-mob-tests = { path = "../tests", default_features = false }
 
-x25519-dalek = { version = "2.0.0-pre.2", default_features = false, features = [ "nightly" ] }
-curve25519-dalek = { version = "4.0.0-pre.2", default_features = false, features = [ "nightly" ] }
-ed25519-dalek = { version = "2.0.0-pre.1", default_features = false, features = [ "nightly" ] }
+curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }
+x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
+ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
 
-mc-core = { version = "4.0.0", features = [ "bip39" ] }
-mc-crypto-keys = { version = "4.0.0", default-features = false }
-mc-crypto-ring-signature = { version = "4.0.0", default-features = false }
-mc-util-from-random = { version = "4.0.0", default-features = false }
+mc-core = { version = "4.1.0-pre0", features = [ "bip39" ] }
+mc-crypto-keys = { version = "4.1.0-pre0", default-features = false }
+mc-crypto-ring-signature = { version = "4.1.0-pre0", default-features = false }
+mc-util-from-random = { version = "4.1.0-pre0", default-features = false }
 
 [[bin]]
 name = "ledger-mob-cli"

--- a/lib/src/handle.rs
+++ b/lib/src/handle.rs
@@ -8,7 +8,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use ed25519_dalek::PublicKey;
+use ed25519_dalek::VerifyingKey;
 use futures::executor::block_on;
 use log::debug;
 
@@ -282,7 +282,7 @@ where
         index: u32,
         uri: &str,
         challenge: &[u8],
-    ) -> Result<(PublicKey, [u8; 64]), Error> {
+    ) -> Result<(VerifyingKey, [u8; 64]), Error> {
         let mut buff = [0u8; 256];
 
         debug!("Executing identity challenge");
@@ -313,7 +313,9 @@ where
         // Fetch identity response
 
         let resp = self.exchange::<IdentResp>(IdentGetReq, &mut buff).await?;
-        let public_key = PublicKey::from_bytes(&resp.public_key).map_err(|_| Error::InvalidKey)?;
+
+        let public_key =
+            VerifyingKey::from_bytes(&resp.public_key).map_err(|_| Error::InvalidKey)?;
 
         Ok((public_key, resp.signature))
     }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,14 +31,14 @@ serde = "*"
 serde_json = "*"
 tiny-bip39 = "1.0"
 
-mc-core = { version = "4.0.0", features = [ "bip39" ] }
-mc-crypto-keys = { version = "4.0.0", default-features = false }
-mc-crypto-ring-signature = { version = "4.0.0", default-features = false, features = [ "internals" ] }
-mc-crypto-memo-mac = { version = "4.0.0", default-features = false }
-mc-transaction-core = { version = "4.0.0" }
-mc-transaction-extra = { version = "4.0.0" }
-mc-transaction-signer = { version = "4.0.0" }
-mc-transaction-summary = { version = "4.0.0" }
+mc-core = { version = "4.1.0-pre0", features = [ "bip39" ] }
+mc-crypto-keys = { version = "4.1.0-pre0", default-features = false }
+mc-crypto-ring-signature = { version = "4.1.0-pre0", default-features = false, features = [ "internals" ] }
+mc-crypto-memo-mac = { version = "4.1.0-pre0", default-features = false }
+mc-transaction-core = { version = "4.1.0-pre0" }
+mc-transaction-extra = { version = "4.1.0-pre0" }
+mc-transaction-signer = { version = "4.1.0-pre0" }
+mc-transaction-summary = { version = "4.1.0-pre0" }
 
 mc-util-from-random = { path = "../vendor/mob/util/from-random", default-features = false }
 
@@ -52,9 +52,9 @@ ledger-transport-hid = { path = "../vendor/rs/ledger-transport-hid", optional = 
 hidapi = { version = "1.4.2", optional = true, default_features = false, features = [ "linux-static-hidraw" ] }
 ledger-transport-tcp = { path = "../vendor/rs/ledger-transport-tcp", optional = true }
 
-x25519-dalek = { version = "2.0.0-pre.2", default_features = false, features = ["nightly"] }
-curve25519-dalek = { version = "4.0.0-pre.2", default_features = false, features = ["nightly"] }
-ed25519-dalek = { version = "2.0.0-pre.1", default_features = false, features = ["nightly"] }
+curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }
+x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
+ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
 
 
 [dev-dependencies]

--- a/tests/src/ident.rs
+++ b/tests/src/ident.rs
@@ -7,7 +7,7 @@
 use std::future::Future;
 
 use bip39::{Language, Mnemonic, Seed};
-use ed25519_dalek::{PublicKey, Signature};
+use ed25519_dalek::{Signature, VerifyingKey};
 use ledger_transport::Exchange;
 
 use ledger_mob_apdu::{
@@ -120,7 +120,7 @@ where
     );
 
     // Check challenge signature
-    let public_key = PublicKey::from_bytes(&resp.public_key).unwrap();
+    let public_key = VerifyingKey::from_bytes(&resp.public_key).unwrap();
     public_key
         .verify_strict(&challenge, &Signature::from(resp.signature))
         .unwrap();


### PR DESCRIPTION
swapped to upstream dalek (from repo) w/ fixes for target selection, serde. some cleanup remaining before this is mergable (propagating errors etc.)


cc. @samdealy, can we remove the `x25519-dalek` patch too?