### PR TITLE
CI - fix fw packages / app names in manifests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -412,16 +412,15 @@ jobs:
 
     - name: Setup package files
       run: |
-        cp bin/ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}* .
-        cp bin/app_${{ matrix.platform }}.json .
-        cp fw/assets/mob14x14i.gif .
+        mkdir -p ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}
+        cp bin/ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}.hex ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}/ledger-mob-fw.hex
+        cp bin/app_${{ matrix.platform }}.json ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}/
+        cp fw/assets/mob14x14i.gif ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}/
 
     - name: Build firmware archive
       run: >        
         tar cvf ledger-mob-fw-${{ matrix.platform }}.tgz 
-        ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}.hex 
-        app_${{ matrix.platform }}.json 
-        mob14x14i.gif
+        ledger-mob-fw-${{ matrix.platform }}-${{ env.VERSION }}/
 
     - name: Upload firmware package artifact
       uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 RUSTARGS=--release
 
-
 VERSION=$(shell git describe --dirty=+)
 
 NANOSP_ARGS=
@@ -61,22 +60,17 @@ nanosplus-load: fw/target/nanosplus/release/ledger-mob-fw.hex
 fw/target/%/release/ledger-mob-fw.hex: %
 	arm-none-eabi-objcopy fw/target/$</release/ledger-mob-fw -O ihex $@
 
-# Package nanosplus nanoapp
-package-nanosplus: fw/target/nanosplus/release/ledger-mob-fw.hex
-	tar cvf ledger-mob-fw-nanosplus.tgz \
-		-C fw/target/nanosplus/release \
-		app_nanosplus.json \
-		ledger-mob-fw.hex \
-		mob14x14i.gif
+# Package nanoapp
+package-%: % fw/target/%/release/ledger-mob-fw.hex
+	mkdir -p target/ledger-mob-fw-$<
 
-# Package nanox nanoapp
-package-nanox: fw/target/nanox/release/ledger-mob-fw.hex
-	tar cvf ledger-mob-fw-nanosplus.tgz \
-		-C target/nanox/release \
-		app_nanox.json \
-		ledger-mob-fw.hex \
-		mob14x14i.gif
+	cp fw/target/$</release/ledger-mob-fw.hex target/ledger-mob-fw-$<
+	cp fw/target/$</release/app_$<.json target/ledger-mob-fw-$<
+	cp fw/target/$</release/mob14x14i.gif target/ledger-mob-fw-$<
 
+	tar cvf ledger-mob-fw-$<.tgz \
+		-C target \
+		ledger-mob-fw-$<
 
 # Build speculos simulator
 speculos: 


### PR DESCRIPTION
adds folder to firmware packages and renames firmware hex file to match manifest so `ledgerctl install app_nanosplus.json` works as expected