### PR TITLE
WIP: testing hidapi context fix for device enumeration on macos/aarch64

### DIFF
--- a/core/src/engine/function.rs
+++ b/core/src/engine/function.rs
@@ -136,7 +136,7 @@ impl Function {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub fn summarizer_init(
         &mut self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -717,7 +717,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
     #[cfg_attr(feature = "noinline", inline(never))]
     fn tx_summary_init(
         &mut self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: u32,
         num_outputs: u32,
         num_inputs: u32,

--- a/core/src/engine/summary.rs
+++ b/core/src/engine/summary.rs
@@ -48,7 +48,7 @@ pub enum SummaryState {
 impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     /// Create a new summarizer instance
     pub fn new(
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,
@@ -82,7 +82,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub unsafe fn init(
         p: *mut Self,
-        message: &[u8],
+        message: &[u8; 32],
         block_version: BlockVersion,
         num_outputs: usize,
         num_inputs: usize,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,14 +7,14 @@
 // see https://github.com/rust-lang/rust/issues/91611
 // #![feature(async_fn_in_trait)]
 
-use std::{fmt::Debug};
+use std::fmt::Debug;
 
 pub use ledger_transport::Exchange;
 
 use async_trait::async_trait;
 
 #[cfg(feature = "transport_hid")]
-use hidapi::{HidApi};
+use hidapi::HidApi;
 
 /// Re-export transports for consumer use
 pub mod transport;
@@ -64,7 +64,9 @@ impl LedgerProvider {
     /// NOTE: only one provider may exist at a time (workaround for global HID context errors on macos/m1)
     pub fn new() -> Result<Self, Error> {
         #[cfg(feature = "transport_hid")]
-        return Ok(Self { hid_api: HidApi::new()? });
+        return Ok(Self {
+            hid_api: HidApi::new()?,
+        });
 
         #[cfg(not(feature = "transport_hid"))]
         return Ok(Self {});


### PR DESCRIPTION
it seems that devices are not correctly enumerating on macos/aarch64, allowing a first connection then requiring a restart of the application prior to the next. the command line tool works every time, suggesting this might be related to the `hidapi` context.

recreating the context per `LegderProvider` is not _technically_ valid as multiple providers could create multiple contexts, but should prove the point.

related to #33 