### PR TITLE
support b58 addresses' in view and summaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -469,8 +469,8 @@ jobs:
             ~/.cargo
             ./target
 
-      - name: Install libusb / libudev
-        run: sudo apt update && sudo apt install -y libusb-1.0-0 libusb-1.0-0-dev libudev-dev
+      - name: Install libusb / libudev / protoc
+        run: sudo apt update && sudo apt install -y libusb-1.0-0 libusb-1.0-0-dev libudev-dev protobuf-compiler protobuf-c-compiler 
 
       - name: Build documentation
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       run: echo "RUST_TARGET_PATH=${GITHUB_WORKSPACE}/fw/" >> $GITHUB_ENV
 
     - name: Install cross toolchain, libraries
-      run: sudo apt update && sudo apt install -y gcc-arm-none-eabi gcc-multilib libusb-1.0-0 libusb-1.0-0-dev libudev-dev
+      run: sudo apt update && sudo apt install -y gcc-arm-none-eabi gcc-multilib libusb-1.0-0 libusb-1.0-0-dev libudev-dev protobuf-compiler protobuf-c-compiler 
 
     - name: Restore core cache
       uses: actions/cache/restore@v3
@@ -66,8 +66,10 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly-2023-01-04
-        target:  ${{ matrix.target }}
         override: true
+
+    - name: Install protobuf tools
+      run: sudo apt update && sudo apt install -y protobuf-compiler protobuf-c-compiler 
 
     - name: Restore core cache
       uses: actions/cache/restore@v3
@@ -162,7 +164,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --package ledger-mob --target ${{ matrix.target }} --release ${{ matrix.args }}
+        args: --package ledger-mob --target ${{ matrix.target }} --release
 
     - name: Update ${{ matrix.target }} CLI cache
       if: ${{ github.ref == 'refs/heads/main' }}
@@ -231,7 +233,7 @@ jobs:
         components: rust-src
 
     - name: Install cross toolchain 
-      run: sudo apt update && sudo apt install gcc-arm-none-eabi gcc-multilib
+      run: sudo apt update && sudo apt install gcc-arm-none-eabi gcc-multilib protobuf-compiler protobuf-c-compiler 
 
     - name: Load ${{ matrix.platform }} FW cache
       uses: actions/cache/restore@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arc-swap"
@@ -1011,6 +1011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1044,37 @@ dependencies = [
  "miniz_oxide 0.6.2",
  "smallvec",
  "threadpool",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.105",
+ "synstructure",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1059,9 +1101,15 @@ checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
- "windows-sys",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1252,6 +1300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "grpcio-compiler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f1abac9f330ac9ee0950220c10eea84d66479cede4836f0b924407fecf093c"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1424,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -1590,13 +1653,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.3"
+name = "instant"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1613,8 +1686,8 @@ checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
- "rustix",
- "windows-sys",
+ "rustix 0.36.5",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1786,8 +1859,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitflags",
+ "bs58",
  "byteorder",
  "clear_on_drop",
+ "crc",
  "curve25519-dalek",
  "ed25519-dalek",
  "emstr",
@@ -1800,18 +1875,23 @@ dependencies = [
  "ledger-mob-tests",
  "ledger-transport",
  "log",
+ "mc-account-keys",
+ "mc-api",
  "mc-core",
  "mc-crypto-digestible",
  "mc-crypto-hashes",
  "mc-crypto-keys",
  "mc-crypto-memo-mac",
  "mc-crypto-ring-signature",
+ "mc-fog-sig-authority",
  "mc-transaction-summary",
  "mc-transaction-types",
  "mc-util-from-random",
  "mc-util-test-helper",
  "merlin",
  "num_enum",
+ "prost",
+ "prost-build",
  "rand",
  "rand_core",
  "sha2 0.10.6",
@@ -1937,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libm"
@@ -1961,6 +2041,12 @@ name = "linux-raw-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -2019,6 +2105,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-api"
+version = "4.1.0-pre0"
+dependencies = [
+ "bs58",
+ "cargo-emit",
+ "crc",
+ "curve25519-dalek",
+ "displaydoc",
+ "mc-account-keys",
+ "mc-attest-verifier-types",
+ "mc-blockchain-types",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-crypto-multisig",
+ "mc-crypto-ring-signature-signer",
+ "mc-transaction-core",
+ "mc-transaction-extra",
+ "mc-transaction-summary",
+ "mc-util-build-grpc",
+ "mc-util-build-script",
+ "mc-util-repr-bytes",
+ "mc-util-serial",
+ "mc-watcher-api",
+ "protobuf",
+]
+
+[[package]]
+name = "mc-attest-verifier-types"
+version = "4.1.0-pre0"
+dependencies = [
+ "base64 0.21.0",
+ "displaydoc",
+ "hex",
+ "hex_fmt",
+ "mc-crypto-digestible",
+ "mc-util-encodings",
+ "prost",
+ "serde",
+]
+
+[[package]]
+name = "mc-blockchain-types"
+version = "4.1.0-pre0"
+dependencies = [
+ "displaydoc",
+ "hex_fmt",
+ "mc-account-keys",
+ "mc-attest-verifier-types",
+ "mc-common",
+ "mc-consensus-scp-types",
+ "mc-crypto-digestible",
+ "mc-crypto-digestible-signature",
+ "mc-crypto-keys",
+ "mc-crypto-ring-signature",
+ "mc-transaction-core",
+ "mc-transaction-types",
+ "mc-util-from-random",
+ "mc-util-repr-bytes",
+ "prost",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "mc-common"
 version = "4.1.0-pre0"
 dependencies = [
@@ -2051,6 +2201,18 @@ dependencies = [
  "slog-scope",
  "slog-stdlog",
  "slog-term",
+]
+
+[[package]]
+name = "mc-consensus-scp-types"
+version = "4.1.0-pre0"
+dependencies = [
+ "mc-common",
+ "mc-crypto-digestible",
+ "mc-crypto-keys",
+ "mc-util-from-random",
+ "prost",
+ "serde",
 ]
 
 [[package]]
@@ -2364,6 +2526,7 @@ name = "mc-transaction-summary"
 version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
+ "heapless 0.7.16",
  "mc-account-keys",
  "mc-core",
  "mc-crypto-digestible",
@@ -2397,10 +2560,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-util-build-grpc"
+version = "4.1.0-pre0"
+dependencies = [
+ "mc-util-build-script",
+ "protoc-grpcio",
+]
+
+[[package]]
 name = "mc-util-build-info"
 version = "4.1.0-pre0"
 dependencies = [
  "cargo-emit",
+]
+
+[[package]]
+name = "mc-util-build-script"
+version = "4.1.0-pre0"
+dependencies = [
+ "cargo-emit",
+ "displaydoc",
+ "lazy_static",
+ "url",
+ "walkdir",
+]
+
+[[package]]
+name = "mc-util-encodings"
+version = "4.1.0-pre0"
+dependencies = [
+ "base64 0.21.0",
+ "displaydoc",
+ "hex",
+ "mc-util-repr-bytes",
+ "serde",
 ]
 
 [[package]]
@@ -2470,6 +2663,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-watcher-api"
+version = "4.1.0-pre0"
+dependencies = [
+ "displaydoc",
+ "serde",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,8 +2730,14 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nanorand"
@@ -2682,9 +2889,9 @@ checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2701,6 +2908,16 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -2796,6 +3013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.105",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,6 +3066,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 1.0.105",
+ "tempfile",
+ "which",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +3098,55 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.105",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protoc"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0218039c514f9e14a5060742ecd50427f8ac4f85a6dc58f2ddb806e318c55ee"
+dependencies = [
+ "log",
+ "which",
+]
+
+[[package]]
+name = "protoc-grpcio"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980d0ed845138df84f72beb72faf6d726c70c99d0debb2b5e1e7dee61f853df7"
+dependencies = [
+ "failure",
+ "grpcio-compiler",
+ "protobuf",
+ "protobuf-codegen",
+ "protoc",
+ "tempfile",
 ]
 
 [[package]]
@@ -2932,13 +3230,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -3061,11 +3368,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.1.3",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3100,6 +3421,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schnorrkel-og"
@@ -3720,6 +4050,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.11",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3885,7 +4228,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4074,6 +4417,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,6 +4550,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4233,56 +4597,146 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ ledger-apdu = { path = "./vendor/rs/ledger-apdu" }
 ledger-transport = { path = "./vendor/rs/ledger-transport" }
 #ledger-zondax-generic = { path = "./vendor/rs/ledger-zondax-generic" }
 
+mc-account-keys = { path = "./vendor/mob/account-keys" }
+mc-api = { path = "./vendor/mob/api" }
 mc-core = { path = "./vendor/mob/core" }
 mc-crypto-digestible = { path ="./vendor/mob/crypto/digestible" }
 mc-crypto-hashes = { path ="./vendor/mob/crypto/hashes" }
@@ -49,6 +51,7 @@ mc-crypto-keys = { path ="./vendor/mob/crypto/keys" }
 mc-crypto-memo-mac = { path ="./vendor/mob/crypto/memo-mac" }
 mc-crypto-ring-signature = { path ="./vendor/mob/crypto/ring-signature" }
 mc-crypto-ring-signature-signer = { path ="./vendor/mob/crypto/ring-signature/signer" }
+mc-fog-sig-authority = { path = "./vendor/mob/fog/sig/authority" }
 mc-transaction-core = { path = "./vendor/mob/transaction/core" }
 mc-transaction-extra = { path = "./vendor/mob/transaction/extra" }
 mc-transaction-types = { path = "./vendor/mob/transaction/types" }
@@ -56,6 +59,7 @@ mc-transaction-signer = { path = "./vendor/mob/transaction/signer" }
 mc-transaction-summary = { path = "./vendor/mob/transaction/summary" }
 mc-util-from-random = { path = "./vendor/mob/util/from-random" }
 mc-util-test-helper = { path = "./vendor/mob/util/test-helper" }
+mc-util-serial = { path = "./vendor/mob/util/serial" }
 
 #prost = { path = "../prost" }
 #prost-derive = { path = "../prost/prost-derive" }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION=$(shell git describe --dirty=+)
 NANOSP_ARGS=
 NANOX_ARGS=
 
-SPECULOS_ARGS=
+SPECULOS_ARGS=--zoom=4
 ifdef MNEMONIC
 	SPECULOS_ARGS+=--seed "$(MNEMONIC)"
 endif

--- a/apdu/src/digest.rs
+++ b/apdu/src/digest.rs
@@ -5,7 +5,7 @@
 use sha2::{Digest as _, Sha512_256};
 
 use mc_core::{
-    account::{PublicSubaddress},
+    account::PublicSubaddress,
     keys::{SubaddressViewPublic, TxOutPublic},
 };
 use mc_crypto_keys::CompressedRistrettoPublic;

--- a/apdu/src/lib.rs
+++ b/apdu/src/lib.rs
@@ -154,7 +154,8 @@ pub(crate) mod test {
         let n = apdu.encode(buff).expect("encode failed");
 
         // Ensure encoded data fits maximum APDU payload
-        assert!(n < 249);
+        let m = 249;
+        assert!(n < m, "encoded length {n} exceeds maximum APDU payload {m}");
 
         // Check encoded length matches expected length
         let expected_n = apdu.encode_len().expect("get length failed");

--- a/apdu/src/tx/summary.rs
+++ b/apdu/src/tx/summary.rs
@@ -315,7 +315,7 @@ impl Encode for FogId {
     }
 
     fn encode(&self, buff: &mut [u8]) -> Result<usize, Self::Error> {
-        if buff.len() < 1 {
+        if buff.is_empty() {
             return Err(encdec::Error::Length);
         }
 
@@ -331,7 +331,7 @@ impl DecodeOwned for FogId {
     type Error = encdec::Error;
 
     fn decode_owned(buff: &[u8]) -> Result<(Self::Output, usize), Self::Error> {
-        if buff.len() < 1 {
+        if buff.is_empty() {
             return Err(encdec::Error::Length);
         }
 
@@ -456,7 +456,7 @@ impl TxSummaryAddTxOutUnblinding {
             return None;
         }
 
-        Some((self.fog_id, self.fog_authority_sig.clone()))
+        Some((self.fog_id, self.fog_authority_sig))
     }
 
     /// Compute hash for [TxSummaryAddTxOutUnblinding]

--- a/apdu/src/tx/summary.rs
+++ b/apdu/src/tx/summary.rs
@@ -1,7 +1,9 @@
 #![allow(unused)]
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 
-use encdec::{Decode, Encode};
+use core::str::FromStr;
+
+use encdec::{Decode, DecodeOwned, Encode};
 use ledger_apdu::ApduStatic;
 
 use mc_core::{
@@ -200,7 +202,10 @@ pub struct TxSummaryAddTxOutUnblinding {
     /// TxOut index for idempotency
     pub index: u8,
 
-    pub reserved: [u8; 2],
+    /// Fog ID for address if available
+    pub fog_id: FogId,
+
+    pub reserved: u8,
 
     /// UnmaskedAmount.value
     pub unmasked_value: u64,
@@ -220,13 +225,12 @@ pub struct TxSummaryAddTxOutUnblinding {
     #[encdec(with = "pub_key")]
     pub address_view_public: SubaddressViewPublic,
 
-    // TxOut receiver short address hash
-    #[encdec(with = "arr")]
-    pub address_short_hash: [u8; 16],
-
     // (optional) transaction private key
     #[encdec(with = "pri_key")]
     pub tx_private_key: TxPrivateKey,
+
+    #[encdec(with = "arr")]
+    pub fog_authority_sig: [u8; 64],
 }
 
 bitflags::bitflags! {
@@ -236,10 +240,113 @@ bitflags::bitflags! {
         const HAS_PRIVATE_KEY = 1 << 0;
         /// TxSummaryAddTxOutUnblinding contains address information
         const HAS_ADDRESS = 1 << 1;
+        /// TxSummaryAddTxOutUnblinding contains fog authority signature
+        const HAS_FOG_AUTHORITY_SIG = 1 << 2;
     }
 }
 
 crate::encdec_bitflags!(AddTxOutUnblindingFlags);
+
+/// Fog identifier for resolving account information
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum FogId {
+    /// No fog associated with account
+    None = 0,
+    /// MobileCoin MainNet fog
+    MobMain = 1,
+    /// MobileCoin TestNet fog
+    MobTest = 2,
+    /// Signal MainNet fog
+    SignalMain = 3,
+    /// Signal TestNet fog
+    SignalTest = 4,
+}
+
+impl Default for FogId {
+    fn default() -> Self {
+        FogId::None
+    }
+}
+
+impl FogId {
+    /// Resolve fog ID to URL
+    pub fn url(&self) -> &'static str {
+        match self {
+            FogId::None => "",
+            FogId::MobMain => FOG_MC_MAINNET_URI,
+            FogId::MobTest => FOG_MC_TESTNET_URI,
+            FogId::SignalMain => FOG_SIGNAL_MAINNET_URI,
+            FogId::SignalTest => FOG_SIGNAL_TESTNET_URI,
+        }
+    }
+}
+
+impl FromStr for FogId {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let id = match s {
+            "" => FogId::None,
+            FOG_MC_MAINNET_URI => FogId::MobMain,
+            FOG_MC_TESTNET_URI => FogId::MobTest,
+            FOG_SIGNAL_MAINNET_URI => FogId::SignalMain,
+            FOG_SIGNAL_TESTNET_URI => FogId::SignalTest,
+            _ => return Err(()),
+        };
+        Ok(id)
+    }
+}
+
+/// MobileCoin TestNet fog URI
+const FOG_MC_TESTNET_URI: &str = "fog://fog.test.mobilecoin.com";
+/// MobileCoin MainNet fog URI
+const FOG_MC_MAINNET_URI: &str = "fog://fog.prod.mobilecoinww.com";
+/// Signal TestNet fog URI
+const FOG_SIGNAL_TESTNET_URI: &str = "fog://???";
+/// Signal MainNet fog URI
+const FOG_SIGNAL_MAINNET_URI: &str = "fog://???";
+
+impl Encode for FogId {
+    type Error = encdec::Error;
+
+    fn encode_len(&self) -> Result<usize, Self::Error> {
+        Ok(1)
+    }
+
+    fn encode(&self, buff: &mut [u8]) -> Result<usize, Self::Error> {
+        if buff.len() < 1 {
+            return Err(encdec::Error::Length);
+        }
+
+        buff[0] = *self as u8;
+
+        Ok(1)
+    }
+}
+
+impl DecodeOwned for FogId {
+    type Output = Self;
+
+    type Error = encdec::Error;
+
+    fn decode_owned(buff: &[u8]) -> Result<(Self::Output, usize), Self::Error> {
+        if buff.len() < 1 {
+            return Err(encdec::Error::Length);
+        }
+
+        let id = match buff[0] {
+            0 => FogId::None,
+            1 => FogId::MobMain,
+            2 => FogId::MobTest,
+            3 => FogId::SignalMain,
+            4 => FogId::SignalTest,
+            _ => FogId::None,
+        };
+
+        Ok((id, 1))
+    }
+}
 
 impl ApduStatic for TxSummaryAddTxOutUnblinding {
     const CLA: u8 = MOB_APDU_CLA;
@@ -252,8 +359,9 @@ impl TxSummaryAddTxOutUnblinding {
         index: u8,
         unmasked_amount: &UnmaskedAmount,
         address: Option<(impl RingCtAddress, ShortAddressHash)>,
+        fog_info: Option<(&str, [u8; 64])>,
         tx_private_key: Option<TxPrivateKey>,
-    ) -> Self {
+    ) -> Result<Self, ApduError> {
         // Setup flags
         let mut flags = AddTxOutUnblindingFlags::empty();
         flags.set(AddTxOutUnblindingFlags::HAS_ADDRESS, address.is_some());
@@ -272,19 +380,40 @@ impl TxSummaryAddTxOutUnblinding {
             None => (Default::default(), Default::default(), Default::default()),
         };
 
+        // Parse fog information
+
+        let (fog_id, fog_authority_sig) = match fog_info {
+            Some((url, sig)) => {
+                // Parse fog url
+                let fog_id = match FogId::from_str(url) {
+                    Ok(v) => v,
+                    Err(_) => return Err(ApduError::InvalidEncoding),
+                };
+
+                let mut fog_authority_sig = [0u8; 64];
+                fog_authority_sig.copy_from_slice(&sig);
+
+                flags.insert(AddTxOutUnblindingFlags::HAS_FOG_AUTHORITY_SIG);
+
+                (fog_id, fog_authority_sig)
+            }
+            _ => (FogId::None, [0u8; 64]),
+        };
+
         // Return object
-        Self {
+        Ok(Self {
             flags,
             index,
-            reserved: [0u8; 2],
+            fog_id,
+            reserved: 0,
             unmasked_value: unmasked_amount.value,
             token_id: unmasked_amount.token_id,
             blinding: unmasked_amount.blinding.into(),
             address_spend_public,
             address_view_public,
-            address_short_hash: *address_short_hash.as_ref(),
             tx_private_key: tx_private_key.map(Key::from).unwrap_or_default(),
-        }
+            fog_authority_sig,
+        })
     }
 
     pub fn flags(&self) -> AddTxOutUnblindingFlags {
@@ -309,25 +438,39 @@ impl TxSummaryAddTxOutUnblinding {
         }
     }
 
-    pub fn address(&self) -> Option<(ShortAddressHash, PublicSubaddress)> {
+    pub fn address(&self) -> Option<PublicSubaddress> {
         match self.flags().contains(AddTxOutUnblindingFlags::HAS_ADDRESS) {
-            true => Some((
-                ShortAddressHash::from(self.address_short_hash),
-                PublicSubaddress {
-                    view_public: self.address_view_public.clone(),
-                    spend_public: self.address_spend_public.clone(),
-                },
-            )),
+            true => Some(PublicSubaddress {
+                view_public: self.address_view_public.clone(),
+                spend_public: self.address_spend_public.clone(),
+            }),
             false => None,
         }
     }
 
+    pub fn fog_info(&self) -> Option<(FogId, [u8; 64])> {
+        if !self
+            .flags
+            .contains(AddTxOutUnblindingFlags::HAS_FOG_AUTHORITY_SIG)
+        {
+            return None;
+        }
+
+        Some((self.fog_id, self.fog_authority_sig.clone()))
+    }
+
     /// Compute hash for [TxSummaryAddTxOutUnblinding]
     pub fn hash(&self) -> [u8; 32] {
+        let fog_authority_sig = match self.fog_id {
+            FogId::None => None,
+            _ => Some(&self.fog_authority_sig[..]),
+        };
+
         crate::digest::digest_tx_summary_add_output_unblinding(
             &self.unmasked_amount(),
             self.address().as_ref(),
             self.tx_private_key(),
+            fog_authority_sig,
         )
     }
 }
@@ -464,6 +607,8 @@ impl TxSummaryBuild {
 
 #[cfg(test)]
 mod test {
+    use core::{any::type_name, mem::size_of};
+
     use curve25519_dalek::ristretto::RistrettoPoint;
     use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
     use mc_util_from_random::FromRandom;
@@ -513,18 +658,26 @@ mod test {
         let spend_public = RistrettoPublic::from_random(&mut OsRng {});
         let tx_private_key = RistrettoPrivate::from_random(&mut OsRng {});
 
-        let apdu = TxSummaryAddTxOutUnblinding {
-            flags: AddTxOutUnblindingFlags::HAS_ADDRESS,
-            index: random(),
-            reserved: [0u8; 2],
-            unmasked_value: random(),
-            token_id: random(),
-            blinding: Scalar::random(&mut OsRng {}),
-            address_spend_public: view_public.into(),
-            address_view_public: spend_public.into(),
-            address_short_hash: random(),
-            tx_private_key: tx_private_key.into(),
-        };
+        let hash = ShortAddressHash::from(random::<[u8; 16]>());
+
+        let apdu = TxSummaryAddTxOutUnblinding::new(
+            random(),
+            &UnmaskedAmount {
+                value: random(),
+                token_id: random(),
+                blinding: Scalar::random(&mut OsRng {}).into(),
+            },
+            Some((
+                PublicSubaddress {
+                    view_public: view_public.into(),
+                    spend_public: spend_public.into(),
+                },
+                hash,
+            )),
+            Some((FogId::MobMain.url(), [0xab; 64])),
+            Some(tx_private_key.into()),
+        )
+        .unwrap();
 
         let mut buff = [0u8; 256];
         encode_decode_apdu(&mut buff, &apdu);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,16 +54,18 @@ static_assertions = "1.1.0"
 encdec = { version = "0.8.0", default_features = false }
 thiserror = { version = "1.0.38", optional = true }
 emstr = { version = "0.2.0", default_features = false }
-
-
+prost = { version = "0.11.0", default_features = false, features = [ "prost-derive" ] }
+crc = { version = "3.0.0", default_features = false }
 curve25519-dalek = { version = "4.0.0-rc.1", default_features = false, features = [ "zeroize" ] }
 ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
 x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
 merlin = { version = "3.0.0", default_features = false }
 sha2 = { version = "0.10.6", default_features = false }
+bs58 = { version = "0.4.0", default_features = false }
 
 ledger-apdu = { version = "0.10.0", default_features = false }
 ledger-mob-apdu = { path = "../apdu", default_features = false }
+
 
 mc-core = { version = "4.1.0-pre0", default_features = false, features = [ "internals" ] }
 mc-crypto-digestible = { version = "4.1.0-pre0", default_features = false }
@@ -71,6 +73,7 @@ mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
 mc-crypto-hashes = { version = "4.1.0-pre0", default_features = false }
 mc-crypto-ring-signature = { version = "4.1.0-pre0", optional = true, default_features = false, features = [ "internals" ] }
 mc-crypto-memo-mac = { version = "4.1.0-pre0", optional = true, default_features = false }
+mc-fog-sig-authority = { version = "4.1.0-pre0", default_features = false }
 mc-transaction-types = { version = "4.1.0-pre0", default_features = false }
 mc-transaction-summary = { version = "4.1.0-pre0", default_features = false, optional = true }
 mc-util-from-random = { version = "4.1.0-pre0", default_features = false }
@@ -78,6 +81,11 @@ mc-util-from-random = { version = "4.1.0-pre0", default_features = false }
 
 # used by bulletproofs-og, no_cc feature required for cross compilation
 clear_on_drop = { version = "0.2", default-features = false, features = [ "no_cc" ] }
+
+
+[build-dependencies]
+prost-build = "0.11.0"
+anyhow = "1.0.70"
 
 [dev-dependencies]
 anyhow = "1.0.65"
@@ -91,6 +99,8 @@ slip10_ed25519 = { version = "0.1.3", default_features = false }
 tokio = { version = "1.20.1", features = [ "full" ] }
 async-trait = "0.1.57"
 
+mc-account-keys = { version = "4.1.0-pre0", default_features = false, features = [ "serde" ] }
+mc-api = { version = "4.1.0-pre0", default_features = false }
 mc-util-test-helper = { path = "../vendor/mob/util/test-helper", default_features = false }
 ledger-mob-tests = { path = "../tests", default_features = false }
 ledger-transport = { path = "../vendor/rs/ledger-transport" }

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,9 @@
+fn main() -> anyhow::Result<()> {
+    let mut cfg = prost_build::Config::new();
+    // Replace maps with btree for no_std
+    cfg.btree_map(&["."]);
+
+    cfg.compile_protos(&["mob.proto"], &["./"])?;
+
+    Ok(())
+}

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,7 +1,7 @@
 fn main() -> anyhow::Result<()> {
     let mut cfg = prost_build::Config::new();
     // Replace maps with btree for no_std
-    cfg.btree_map(&["."]);
+    cfg.btree_map(["."]);
 
     cfg.compile_protos(&["mob.proto"], &["./"])?;
 

--- a/core/mob.proto
+++ b/core/mob.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package mob;
+
+/// A 32-byte compressed Ristretto curve point (public key)
+message CompressedRistretto {
+    bytes data = 1;
+}
+
+/// A public address, used to identify recipients.
+message PublicAddress {
+    /// View public key
+    CompressedRistretto view_public_key = 1;
+
+    /// Spend public key
+    CompressedRistretto spend_public_key = 2;
+
+    /// Optional url of fog report server.
+    /// Empty string when not in use, i.e. for accounts that don't have fog service.
+    /// Indicates the place at which the fog report server should be contacted.
+    string fog_report_url = 3;
+
+    /// Optional fog report id.
+    /// The fog report server may serve multiple reports, this id disambiguates
+    /// which one to use when sending to this account.
+    string fog_report_id = 4;
+
+    /// View key signature over the fog authority subjectPublicKeyInfo.
+    ///
+    /// This must be parseable as a RistrettoSignature.
+    bytes fog_authority_sig = 5;
+}
+
+/// This wraps all of the above messages using "oneof", allowing us to
+/// have a single encoding scheme and extend as necessary simply by adding
+/// new messages without breaking backwards compatibility
+message PrintableWrapper { oneof wrapper {
+    PublicAddress public_address = 1;
+}}

--- a/core/src/engine/event.rs
+++ b/core/src/engine/event.rs
@@ -269,7 +269,7 @@ impl<'a> Event<'a> {
                 unmasked_amount,
                 address.as_ref(),
                 tx_private_key.as_ref(),
-                fog_info.as_ref().map(|(_id, sig)| &sig[..] ),
+                fog_info.as_ref().map(|(_id, sig)| &sig[..]),
             ),
             Event::TxSummaryAddInput {
                 pseudo_output_commitment,

--- a/core/src/engine/event.rs
+++ b/core/src/engine/event.rs
@@ -17,7 +17,10 @@ use mc_crypto_ring_signature::{CompressedCommitment, CurveScalar, ReducedTxOut, 
 use mc_transaction_types::{Amount, MaskedAmount, UnmaskedAmount};
 
 use ledger_apdu::{ApduError, ApduStatic};
-use ledger_mob_apdu::{prelude::*, tx::AddTxInFlags};
+use ledger_mob_apdu::{
+    prelude::*,
+    tx::{AddTxInFlags, FogId},
+};
 
 /// [`Engine`][super::Engine] input events, typically decoded from request [APDUs][crate::apdu]
 #[derive(Clone, Debug)]
@@ -96,7 +99,8 @@ pub enum Event<'a> {
     #[cfg(feature = "summary")]
     TxSummaryAddOutputUnblinding {
         unmasked_amount: UnmaskedAmount,
-        address: Option<(ShortAddressHash, PublicSubaddress)>,
+        address: Option<PublicSubaddress>,
+        fog_info: Option<(FogId, [u8; 64])>,
         tx_private_key: Option<TxPrivateKey>,
     },
 
@@ -259,11 +263,13 @@ impl<'a> Event<'a> {
             Event::TxSummaryAddOutputUnblinding {
                 unmasked_amount,
                 address,
+                fog_info,
                 tx_private_key,
             } => digest_tx_summary_add_output_unblinding(
                 unmasked_amount,
                 address.as_ref(),
                 tx_private_key.as_ref(),
+                fog_info.as_ref().map(|(_id, sig)| &sig[..] ),
             ),
             Event::TxSummaryAddInput {
                 pseudo_output_commitment,
@@ -405,6 +411,7 @@ impl<'a> From<TxSummaryAddTxOutUnblinding> for Event<'a> {
                 blinding: CurveScalar::from(a.blinding),
             },
             address: a.address(),
+            fog_info: a.fog_info(),
             tx_private_key: a.tx_private_key().cloned(),
         }
     }

--- a/core/src/engine/fog.rs
+++ b/core/src/engine/fog.rs
@@ -1,0 +1,34 @@
+pub use ledger_mob_apdu::tx::FogId;
+
+/// Fog certificate information for [FogId] types
+pub trait FogCert {
+    fn spki(&self) -> &str;
+}
+
+impl FogCert for FogId {
+    /// Fetch SPKI string for a given [FogId]
+    fn spki(&self) -> &str {
+        match self {
+            FogId::MobTest => FOG_MC_TESTNET_SPKI_STR,
+            FogId::MobMain => FOG_MC_MAINNET_SPKI_STR,
+            FogId::SignalTest => FOG_SIGNAL_TESTNET_SPKI_STR,
+            FogId::SignalMain => FOG_SIGNAL_MAINNET_SPKI_STR,
+            _ => "",
+        }
+    }
+}
+
+/// MobileCoin TestNet fog SPKI
+const FOG_MC_TESTNET_SPKI_STR: &str = r#"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvnB9wTbTOT5uoizRYaYbw7XIEkInl8E7MGOAQj+xnC+F1rIXiCnc/t1+5IIWjbRGhWzo7RAwI5sRajn2sT4rRn9NXbOzZMvIqE4hmhmEzy1YQNDnfALAWNQ+WBbYGW+Vqm3IlQvAFFjVN1YYIdYhbLjAPdkgeVsWfcLDforHn6rR3QBZYZIlSBQSKRMY/tywTxeTCvK2zWcS0kbbFPtBcVth7VFFVPAZXhPi9yy1AvnldO6n7KLiupVmojlEMtv4FQkk604nal+j/dOplTATV8a9AJBbPRBZ/yQg57EG2Y2MRiHOQifJx0S5VbNyMm9bkS8TD7Goi59aCW6OT1gyeotWwLg60JRZTfyJ7lYWBSOzh0OnaCytRpSWtNZ6barPUeOnftbnJtE8rFhF7M4F66et0LI/cuvXYecwVwykovEVBKRF4HOK9GgSm17mQMtzrD7c558TbaucOWabYR04uhdAc3s10MkuONWG0wIQhgIChYVAGnFLvSpp2/aQEq3xrRSETxsixUIjsZyWWROkuA0IFnc8d7AmcnUBvRW7FT/5thWyk5agdYUGZ+7C1o69ihR1YxmoGh69fLMPIEOhYh572+3ckgl2SaV4uo9Gvkz8MMGRBcMIMlRirSwhCfozV2RyT5Wn1NgPpyc8zJL7QdOhL7Qxb+5WjnCVrQYHI2cCAwEAAQ=="#;
+
+/// MobileCoin MainNet fog SPKI
+const FOG_MC_MAINNET_SPKI_STR: &str = r#"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyr/99fvxi104MLgDgvWPVt01TuTJ+rN4qcNBUbF5i3EMM5zDZlugFHKPYPv7flCh5yDDYyLQHfWkxPQqCBAqlhSrCakvQH3HqDSpbM5FJg7pt0k5w+UQGWvP079iSEO5fMRhjE/lORkvk3/UKr2yIXjZ19iEgP8hlhk9xkI42DSg0iIhk59k3wEYPMGSkVarqlPoKBzx2+11CieXnbCkRvoNwLvdzLceY8QNoLc6h2/nht4bcjDCdB0MKNSKFLVp6XNHkVF66jC7QWTZRA/d4pgI5xa+GmkQ90zDZC2sBc+xfquVIVtk0nEvqSkUDZjv7AcJaq/VdPu4uj773ojrZz094PI4Q6sdbg7mfWrcq3ZQG8t9RDXD+6cgugCTFx2Cq/vJhDAPbQHmCEaMoXv2sRSfOhRjtMP1KmKUw5zXmAZa7s88+e7UXRQC+SS77V8s3hinE/I5Gqa/lzl73smhXx8l4CwGnXzlQ5h1lgEHnYLRFnIenNw/mdMGKlWH5HwHLX3hIujERCPAnGLDt+4MjcUiU0spDH3hC9mjPVA3ltaA3+Mk2lDw0kLrZ4Gv3/Ik9WPlYetOuWteMkR1fz6VOc13+WoTJPz0dVrJsK2bUz+YvdBsoHQBbUpCkmnQ5Ok+yiuWa5vYikEJ24SEr8wUiZ4Oe12KVEcjyDIxp6QoE8kCAwEAAQ=="#;
+
+/// Signal TestNet fog SPKI
+const FOG_SIGNAL_TESTNET_SPKI_STR: &str = r#"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAoCMq8nnjTq5EEQ4EI7yrABL9P4y4h1P/h0DepWgXx+w/fywcfRSZINxbaMpvcV3uSJayExrpV1KmaS2wfASeYhSj+rEzAm0XUOw3Q94NOx5A/dOQag/d1SS6/QpF3PQYZTULnRFetmM4yzEnXsXcWtzEu0hh02wYJbLeAq4CCcPTPe2qckrbUP9sD18/KOzzNeypF4p5dQ2m/ezfxtgaLvdUMVDVIAs2v9a5iu6ce4bIcwTIUXgX0w3+UKRx8zqowc3HIqo9yeaGn4ZOwQHvAJZecPmb2pH1nK+BtDUvHpvf+Y3/NJxwh+IPp6Ef8aoUxs2g5oIBZ3Q31fjS2Bh2gmwoVooyytEysPAHvRPVBxXxLi36WpKfk1Vq8K7cgYh3IraOkH2/l2Pyi8EYYFkWsLYofYogaiPzVoq2ZdcizfoJWIYei5mgq+8m0ZKZYLebK1i2GdseBJNIbSt3wCNXZxyN6uqFHOCB29gmA5cbKvs/j9mDz64PJe9LCanqcDQV1U5l9dt9UdmUt7Ab1PjBtoIFaP+u473Z0hmZdCgAivuiBMMYMqt2V2EIw4IXLASE3roLOYp0p7h0IQHb+lVIuEl0ZmwAI30ZmzgcWc7RBeWD1/zNt55zzhfPRLx/DfDY5Kdp6oFHWMvI2r1/oZkdhjFp7pV6qrl7vOyR5QqmuRkCAwEAAQ=="#;
+
+/// Signal MainNet fog SPKI
+const FOG_SIGNAL_MAINNET_SPKI_STR: &str = r#"MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAxaNIOgcoQtq0S64dFVha6rn0hDv/ec+W0cKRdFKygiyp5xuWdW3YKVAkK1PPgSDD2dwmMN/1xcGWrPMqezx1h1xCzbr7HL7XvLyFyoiMB2JYd7aoIuGIbHpCOlpm8ulVnkOX7BNuo0Hi2F0AAHyTPwmtVMt6RZmae1Z/Pl2I06+GgWN6vufV7jcjiLT3yQPsn1kVSj+DYCf3zq+1sCknKIvoRPMdQh9Vi3I/fqNXz00DSB7lt3v5/FQ6sPbjljqdGD/qUl4xKRW+EoDLlAUfzahomQOLXVAlxcws3Ua5cZUhaJi6U5jVfw5Ng2N7FwX/D5oX82r9o3xcFqhWpGnfSxSrAudv1X7WskXomKhUzMl/0exWpcJbdrQWB/qshzi9Et7HEDNY+xEDiwGiikj5f0Lb+QA4mBMlAhY/cmWec8NKi1gf3Dmubh6c3sNteb9OpZ/irA3AfE8jI37K1rvezDI8kbNtmYgvyhfz0lZzRT2WAfffiTe565rJglvKa8rh8eszKk2HC9DyxUb/TcyL/OjGhe2fDYO2t6brAXCqjPZAEkVJq3I30NmnPdE19SQeP7wuaUIb3U7MGxoZC/NuJoxZh8svvZ8cyqVjG+dOQ6/UfrFY0jiswT8AsrfqBis/ZV5EFukZr+zbPtg2MH0H3tSJ14BCLduvc7FY6lAZmOcCAwEAAQ=="#;
+
+#[cfg(test)]
+mod test {}

--- a/core/src/engine/function.rs
+++ b/core/src/engine/function.rs
@@ -2,7 +2,10 @@
 
 use core::mem::MaybeUninit;
 
-use mc_core::keys::{RootViewPrivate, SubaddressSpendPrivate};
+use mc_core::{
+    account::PublicSubaddress,
+    keys::{RootViewPrivate, SubaddressSpendPrivate},
+};
 use mc_transaction_types::BlockVersion;
 
 use super::Error;
@@ -141,8 +144,10 @@ impl Function {
         num_outputs: usize,
         num_inputs: usize,
         view_private_key: &RootViewPrivate,
+        change_subaddress: &PublicSubaddress,
     ) -> &mut Summarizer<MAX_RECORDS> {
         // Clear function prior to init (executes drop)
+
         self.clear();
 
         // Setup uninitialised context
@@ -163,6 +168,7 @@ impl Function {
                 num_outputs,
                 num_inputs,
                 view_private_key,
+                change_subaddress,
             )
         };
 

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -13,7 +13,7 @@ use rand_core::{CryptoRngCore, OsRng};
 use strum::{Display, EnumIter, EnumString, EnumVariantNames};
 
 use mc_core::{
-    account::{Account, RingCtAddress, ShortAddressHash, PublicSubaddress},
+    account::{Account, PublicSubaddress, RingCtAddress, ShortAddressHash},
     keys::{SubaddressViewPublic, TxOutPublic},
     slip10::{wallet_path, Slip10Key},
     subaddress::Subaddress,
@@ -523,9 +523,13 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
 
         let p = PublicSubaddress::from(&s);
 
-        let short_hash = digest_public_address(&p, fog_id.url(), sig.as_ref().map(|v| &v[..] ).unwrap_or(&[]));
+        let short_hash = digest_public_address(
+            &p,
+            fog_id.url(),
+            sig.as_ref().map(|v| &v[..]).unwrap_or(&[]),
+        );
 
-        OutputAddress{
+        OutputAddress {
             short_hash,
             address: p,
             fog_id,
@@ -599,10 +603,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
     /// Resolve address if available
     #[cfg(feature = "summary")]
     pub fn address(&self, h: &ShortAddressHash) -> Option<&OutputAddress> {
-        self.function
-            .summarizer_ref()
-            .map(|v| v.address(h))
-            .flatten()
+        self.function.summarizer_ref().and_then(|v| v.address(h))
     }
 
     /// Noop report if summary feature is disabled

--- a/core/src/engine/summary.rs
+++ b/core/src/engine/summary.rs
@@ -1,11 +1,15 @@
 #![allow(unused)]
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 
+use alloc::string::ToString;
+use heapless::Vec;
+
+use ledger_mob_apdu::tx::FogId;
 use strum::{Display, EnumIter, EnumString, EnumVariantNames};
 
 use mc_core::{
     account::{PublicSubaddress, ShortAddressHash},
-    keys::{RootViewPrivate, TxOutPublic, TxOutTargetPublic},
+    keys::{RootViewPrivate, SubaddressViewPublic, TxOutPublic, TxOutTargetPublic},
 };
 use mc_crypto_digestible::{DigestTranscript, Digestible};
 use mc_crypto_keys::{CompressedRistrettoPublic, RistrettoPublic};
@@ -18,7 +22,7 @@ use mc_transaction_types::{
     Amount, BlockVersion, MaskedAmount, TxInSummary, TxOutSummary, UnmaskedAmount,
 };
 
-use crate::apdu::tx::TxPrivateKey;
+use crate::{apdu::tx::TxPrivateKey, helpers::digest_public_address};
 
 use super::{Error, Event};
 
@@ -27,6 +31,7 @@ pub struct Summarizer<const MAX_RECORDS: usize = 16> {
     state: SummaryState,
     verifier: Option<TxSummaryStreamingVerifierCtx>,
     report: TxSummaryUnblindingReport<MAX_RECORDS>,
+    addresses: Vec<OutputAddress, MAX_RECORDS>,
     tx_out_summary: Option<TxOutSummary>,
     num_outputs: usize,
     num_inputs: usize,
@@ -45,6 +50,18 @@ pub enum SummaryState {
     Complete,
 }
 
+/// Cached output address for later rendering
+pub struct OutputAddress {
+    /// Short address hash, matched against report entries
+    pub short_hash: ShortAddressHash,
+    /// Public address
+    pub address: PublicSubaddress,
+    /// Fog information
+    pub fog_id: FogId,
+    /// Fog signature
+    pub fog_sig: Option<[u8; 64]>,
+}
+
 impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     /// Create a new summarizer instance
     pub fn new(
@@ -53,6 +70,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
         num_outputs: usize,
         num_inputs: usize,
         view_private_key: &RootViewPrivate,
+        change_address: &PublicSubaddress,
     ) -> Self {
         // TODO: check message length
 
@@ -63,6 +81,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
             num_outputs,
             num_inputs,
             view_private_key.clone().inner(),
+            change_address.clone(),
         ));
 
         let report = TxSummaryUnblindingReport::default();
@@ -71,6 +90,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
             state: SummaryState::Init,
             verifier,
             report,
+            addresses: Vec::new(),
             tx_out_summary: None,
             num_outputs,
             num_inputs,
@@ -87,6 +107,7 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
         num_outputs: usize,
         num_inputs: usize,
         view_private_key: &RootViewPrivate,
+        change_address: &PublicSubaddress,
     ) {
         p.write(Self {
             state: SummaryState::Init,
@@ -96,8 +117,10 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
                 num_outputs,
                 num_inputs,
                 view_private_key.clone().inner(),
+                change_address.clone(),
             )),
             report: TxSummaryUnblindingReport::default(),
+            addresses: Vec::new(),
             tx_out_summary: None,
             num_outputs,
             num_inputs,
@@ -139,7 +162,8 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     pub fn add_output_unblinding(
         &mut self,
         unmasked_amount: &UnmaskedAmount,
-        address: Option<(ShortAddressHash, &PublicSubaddress)>,
+        address: Option<&PublicSubaddress>,
+        fog_info: Option<(FogId, &[u8; 64])>,
         tx_private_key: Option<&TxPrivateKey>,
     ) -> Result<SummaryState, Error> {
         // TODO: check state
@@ -165,11 +189,29 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
             }
         };
 
+        // Regenerate short hash for address
+        let (fog_url, fog_sig) = fog_info
+            .map(|(f, s)| (f.url(), &s[..]))
+            .unwrap_or(("", &[]));
+        let a = address.map(|a| (digest_public_address(a, fog_url, fog_sig), a));
+
+        // Cache output address' for future display
+        if let Some((h, _)) = &a {
+            if self.addresses.iter().find(|v| &v.short_hash == h).is_none() {
+                self.addresses.push(OutputAddress {
+                    short_hash: h.clone(),
+                    address: address.cloned().unwrap(),
+                    fog_id: fog_info.map(|(f, _)| f).unwrap_or_default(),
+                    fog_sig: fog_info.map(|(_, s)| s.clone()),
+                });
+            }
+        }
+
         // Digest output w/ unblinding info
         match verifier.digest_output(
             &tx_out_summary,
             unmasked_amount,
-            address,
+            a,
             tx_private_key.as_ref().map(|v| v.as_ref()),
             &mut self.report,
         ) {
@@ -300,12 +342,21 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
     pub fn report(&self) -> &TxSummaryUnblindingReport<MAX_RECORDS> {
         &self.report
     }
+
+    /// Fetch address from summarizer cache (must be called after `finalize`)
+    #[inline]
+    pub fn address(&self, h: &ShortAddressHash) -> Option<&OutputAddress> {
+        self.addresses.iter().find(|v| &v.short_hash == h)
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use core::str::FromStr;
+
     use log::*;
-    use mc_core::{account::Account, keys::Key};
+    use mc_core::consts::CHANGE_SUBADDRESS_INDEX;
+    use mc_core::{account::Account, keys::Key, subaddress::Subaddress};
     use mc_transaction_summary::verify_tx_summary;
     use rand_core::OsRng;
 
@@ -341,6 +392,7 @@ mod test {
             &summary,
             &unblinding_data,
             account.view_private_key().clone().inner(),
+            &account.subaddress(CHANGE_SUBADDRESS_INDEX),
         )
         .unwrap();
 
@@ -357,6 +409,7 @@ mod test {
             summary.outputs.len(),
             summary.inputs.len(),
             account.view_private_key(),
+            &PublicSubaddress::from(&account.subaddress(CHANGE_SUBADDRESS_INDEX)),
         );
 
         let progress_total = summary.inputs.len() + summary.outputs.len() + 1;
@@ -374,15 +427,26 @@ mod test {
             )
             .unwrap();
 
-            let a = unblinding
-                .address
-                .as_ref()
-                .map(|a| (ShortAddressHash::from(a), PublicSubaddress::from(a)));
+            let address = unblinding.address.as_ref();
             let k = unblinding.tx_private_key.map(Key::from);
+
+            let fog_info = address
+                .map(|a| match (a.fog_report_url(), a.fog_authority_sig()) {
+                    (Some(url), Some(s)) => {
+                        let fog_id = FogId::from_str(url).unwrap();
+
+                        let mut sig = [0u8; 64];
+                        sig.copy_from_slice(s.as_ref());
+                        Some((fog_id, sig))
+                    }
+                    _ => None,
+                })
+                .flatten();
 
             s.add_output_unblinding(
                 &unblinding.unmasked_amount,
-                (&a).as_ref().map(|(h, p)| (h.clone(), p)),
+                address.map(|a| PublicSubaddress::from(a)).as_ref(),
+                fog_info.as_ref().map(|(url, sig)| (*url, sig)),
                 (&k).as_ref(),
             )
             .unwrap();
@@ -458,6 +522,6 @@ mod test {
     fn summarizer_size() {
         // TODO: check summarizer size is reasonable
         let s = core::mem::size_of::<Summarizer<16>>();
-        assert!(s < 2048, "summarizer size: {s}");
+        assert!(s < 8192, "summarizer size: {s} > 8192");
     }
 }

--- a/core/src/helpers/mod.rs
+++ b/core/src/helpers/mod.rs
@@ -3,8 +3,17 @@
 use core::{ops::Deref, str::from_utf8};
 
 use emstr::{helpers::Fractional, EncodeStr};
+use prost::{
+    bytes::{BufMut, BytesMut},
+    Message,
+};
+
+use mc_core::account::{RingCtAddress, ShortAddressHash};
 
 use crate::engine::TokenId;
+
+// Include generated protobuf types
+include!(concat!(env!("OUT_DIR"), "/mob.rs"));
 
 /// Per-token information
 struct TokenInfo {
@@ -69,11 +78,144 @@ pub fn fmt_token_val(value: i64, token_id: TokenId, buff: &mut [u8]) -> &str {
     }
 }
 
+/// Helper to digest PublicAddress equivalents for [ShortAddressHash]
+/// without requiring mc-account-keys (or alloc / bytes).
+///
+/// This is a re-implementation of the derived [Digestible] for PublicAddress, with tests to ensure these remain in-sync.
+#[cfg_attr(feature = "noinline", inline(never))]
+pub(crate) fn digest_public_address(
+    subaddress: impl RingCtAddress,
+    fog_report_url: &str,
+    fog_authority_sig: &[u8],
+) -> ShortAddressHash {
+    use mc_crypto_digestible::{DigestTranscript, Digestible, MerlinTranscript};
+
+    // Setup transcript
+    let context = b"mc-address";
+    let mut transcript = <MerlinTranscript as DigestTranscript>::new();
+
+    // Write [PublicAddress] equivalent transcript
+    transcript.append_agg_header(context, "PublicAddress".as_bytes());
+    subaddress
+        .view_public_key()
+        .inner()
+        .append_to_transcript_allow_omit("view_public_key".as_bytes(), &mut transcript);
+    subaddress
+        .spend_public_key()
+        .inner()
+        .append_to_transcript_allow_omit("spend_public_key".as_bytes(), &mut transcript);
+    fog_report_url.append_to_transcript("fog_report_url".as_bytes(), &mut transcript);
+    r#""#.append_to_transcript("fog_report_id".as_bytes(), &mut transcript);
+    fog_authority_sig.append_to_transcript("fog_authority_sig".as_bytes(), &mut transcript);
+    transcript.append_agg_closer(context, "PublicAddress".as_bytes());
+
+    // Extract digest
+    let mut digest = [0u8; 32];
+    transcript.extract_digest(&mut digest);
+
+    // Return first 16 bytes as ShortAddressHash
+    let hash: [u8; 16] = digest[0..16].try_into().expect("arithmetic error");
+    return ShortAddressHash::from(hash);
+}
+
+/// Helper to b58 encode [PublicAddress] equivalent types without
+/// pulling in no-std incompatible `mc_api` dependency.
+#[cfg_attr(feature = "noinline", inline(never))]
+pub fn b58_encode_public_address<const N: usize>(
+    subaddress: impl RingCtAddress,
+    fog_report_url: &str,
+    fog_authority_sig: &[u8],
+) -> Result<heapless::String<N>, ()> {
+    use alloc::string::ToString;
+
+    use printable_wrapper::*;
+
+    let view_public = subaddress.view_public_key();
+    let spend_public = subaddress.spend_public_key();
+
+    // Build printable protobuf wrapper
+    // NOTE: this uses prost / is heavily alloc'd under the hood
+    let p = PrintableWrapper {
+        wrapper: Some(Wrapper::PublicAddress(PublicAddress {
+            view_public_key: Some(CompressedRistretto {
+                data: view_public.to_bytes().to_vec(),
+            }),
+            spend_public_key: Some(CompressedRistretto {
+                data: spend_public.to_bytes().to_vec(),
+            }),
+            fog_report_url: fog_report_url.to_string(),
+            fog_report_id: "".to_string(),
+            fog_authority_sig: fog_authority_sig.to_vec(),
+        })),
+    };
+
+    // Encode to temporary byte buffer
+    // TODO: prefer not to use alloc here but, BuffMut seems to be broken for
+    // const generic types?!
+    let mut data = BytesMut::with_capacity(p.encoded_len() + 4);
+    // Pre-allocate space for checksum
+    data.put_bytes(0, 4);
+    // Encode proto to buffer
+    p.encode(&mut data).unwrap();
+
+    // Force drop `p` to free up heap memory
+    drop(p);
+
+    // Compute checksum for encoded address
+    let checksum = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC)
+        .checksum(&data[4..])
+        .to_le_bytes();
+
+    // Write checksum to start of buffer
+    data[0..4].copy_from_slice(&checksum);
+
+    // Encode address to b58
+    let mut buff = HeaplessEncodeTarget::<N>(heapless::String::new());
+    let _n = bs58::encode(&data).into(&mut buff).unwrap();
+
+    Ok(buff.0)
+}
+
+/// Helper to support bs58 encoding to [heapless::String] types
+struct HeaplessEncodeTarget<const N: usize>(heapless::String<N>);
+
+impl<const N: usize> bs58::encode::EncodeTarget for HeaplessEncodeTarget<N> {
+    fn encode_with(
+        &mut self,
+        max_len: usize,
+        f: impl for<'a> FnOnce(&'a mut [u8]) -> bs58::encode::Result<usize>,
+    ) -> bs58::encode::Result<usize> {
+        // Fetch vec and resize
+        let v = unsafe { self.0.as_mut_vec() };
+        v.resize_default(max_len)
+            .map_err(|_| bs58::encode::Error::BufferTooSmall)?;
+
+        // Encode into resized vec
+        let n = match f(&mut v[..]) {
+            Ok(n) => n,
+            Err(e) => {
+                // On encoding failure clear vec to avoid returning
+                // invalid utf8 string
+                v.clear();
+                return Err(e);
+            }
+        };
+
+        // Truncate down to encoded len
+        v.truncate(n);
+
+        Ok(n)
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use mc_account_keys::AccountKey;
     use mc_transaction_types::TokenId;
+    use rand_core::OsRng;
 
-    use super::{fmt_token_val, SCALAR_MOB};
+    use super::*;
+    use crate::engine::{FogCert, FogId};
 
     const MAX_LINE_LEN: usize = 20;
 
@@ -106,6 +248,104 @@ mod test {
                 MAX_LINE_LEN,
                 s
             );
+        }
+    }
+
+    const FOGS: &[FogId] = &[
+        FogId::MobMain,
+        FogId::MobTest,
+        FogId::SignalMain,
+        FogId::SignalTest,
+    ];
+
+    #[test]
+    fn short_address_hash_no_fog() {
+        for _i in 0..10 {
+            // Create random account without fog info
+            let a = AccountKey::random(&mut OsRng {});
+
+            println!("A: {:?}", a);
+
+            // Test short address hashing
+            let h1 = ShortAddressHash::from(&a.default_subaddress());
+            let h2 = digest_public_address(a.default_subaddress(), "", &[]);
+
+            assert_eq!(h1, h2);
+        }
+    }
+
+    #[test]
+    fn short_address_hash_with_fog() {
+        for f in FOGS {
+            for _i in 0..10 {
+                // Create random account with fog info
+                let a =
+                    AccountKey::random(&mut OsRng {}).with_fog(f.url(), "", f.spki().as_bytes());
+                let p = a.default_subaddress();
+
+                // Test short address hashing
+                let h1 = ShortAddressHash::from(&p);
+                let h2 = digest_public_address(
+                    &p,
+                    p.fog_report_url().unwrap_or(""),
+                    p.fog_authority_sig().unwrap_or(&[]),
+                );
+
+                assert_eq!(h1, h2);
+            }
+        }
+    }
+
+    const B58_MAX_LEN: usize = 512;
+
+    #[test]
+    fn b58_address_no_fog() {
+        for _i in 0..10 {
+            // Create random account without fog info
+            let a = AccountKey::random(&mut OsRng {});
+            let p = a.default_subaddress();
+
+            // Local b58 encoding
+            let s1 = b58_encode_public_address::<B58_MAX_LEN>(
+                &p,
+                p.fog_report_url().unwrap_or(""),
+                p.fog_authority_sig().unwrap_or(&[]),
+            )
+            .unwrap();
+
+            // API standard b58 encoding
+            let mut wrapper = mc_api::printable::PrintableWrapper::new();
+            wrapper.set_public_address((&p).into());
+            let s2 = wrapper.b58_encode().unwrap();
+
+            assert_eq!(s1.as_str(), s2.as_str());
+        }
+    }
+
+    #[test]
+    fn b58_address_with_fog() {
+        for f in FOGS {
+            for _i in 0..10 {
+                // Create random account with fog info
+                let a =
+                    AccountKey::random(&mut OsRng {}).with_fog(f.url(), "", f.spki().as_bytes());
+                let p = a.default_subaddress();
+
+                // Local b58 encoding
+                let s1 = b58_encode_public_address::<B58_MAX_LEN>(
+                    &p,
+                    p.fog_report_url().unwrap_or(""),
+                    p.fog_authority_sig().unwrap_or(&[]),
+                )
+                .unwrap();
+
+                // API standard b58 encoding
+                let mut wrapper = mc_api::printable::PrintableWrapper::new();
+                wrapper.set_public_address((&p).into());
+                let s2 = wrapper.b58_encode().unwrap();
+
+                assert_eq!(s1.as_str(), s2.as_str());
+            }
         }
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -76,6 +76,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 pub use ledger_mob_apdu::{self as apdu};
 
 pub mod engine;

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayref"
@@ -114,6 +114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
@@ -517,6 +529,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "exr"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,10 +565,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -639,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +731,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -773,6 +833,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "jpeg-decoder"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +897,12 @@ checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
 dependencies = [
  "cpufeatures",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lebe"
@@ -847,9 +952,12 @@ name = "ledger-mob-core"
 version = "0.10.0"
 dependencies = [
  "aes",
+ "anyhow",
  "bitflags",
+ "bs58",
  "byteorder",
  "clear_on_drop",
+ "crc",
  "curve25519-dalek",
  "ed25519-dalek",
  "emstr",
@@ -864,11 +972,14 @@ dependencies = [
  "mc-crypto-keys",
  "mc-crypto-memo-mac",
  "mc-crypto-ring-signature",
+ "mc-fog-sig-authority",
  "mc-transaction-summary",
  "mc-transaction-types",
  "mc-util-from-random",
  "merlin",
  "num_enum",
+ "prost",
+ "prost-build",
  "rand_core",
  "sha2",
  "static_assertions",
@@ -891,6 +1002,7 @@ dependencies = [
  "emstr",
  "encdec",
  "getrandom",
+ "heapless 0.8.0",
  "hex_fmt",
  "hmac-sha512",
  "image",
@@ -933,6 +1045,12 @@ name = "linked_list_allocator"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -1081,10 +1199,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mc-fog-sig-authority"
+version = "4.1.0-pre0"
+dependencies = [
+ "mc-crypto-keys",
+]
+
+[[package]]
 name = "mc-transaction-summary"
 version = "4.1.0-pre0"
 dependencies = [
  "displaydoc",
+ "heapless 0.7.16",
  "mc-core",
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -1170,6 +1296,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "nanos_sdk"
 version = "0.2.0"
-source = "git+https://github.com/LedgerHQ/ledger-nanos-sdk?rev=master#bdcddd741ff39919257d487aeeb6832e5cd990ef"
+source = "git+https://github.com/LedgerHQ/ledger-nanos-sdk?rev=master#a4092821398d27413d9cc1209209e0c63ebc5459"
 dependencies = [
  "cc",
  "num-traits",
@@ -1239,7 +1371,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1283,6 +1415,16 @@ checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
  "libm",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -1334,12 +1476,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1392,6 +1598,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
 name = "rlibc"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1634,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1609,6 +1853,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +2008,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +2050,138 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.0-pre.2"
 source = "git+https://github.com/mobilecoinfoundation/x25519-dalek.git?rev=4fbaa3343301c62cfdbc3023c9f485257e6b718a#4fbaa3343301c62cfdbc3023c9f485257e6b718a"
@@ -1811,3 +2211,11 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "mc-account-keys"
+version = "4.1.0-pre0"
+
+[[patch.unused]]
+name = "mc-util-serial"
+version = "4.1.0-pre0"

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -47,6 +47,7 @@ strum = { version = "0.24.1", default_features = false }
 hex_fmt = { version = "0.3.0", default_features = false }
 encdec = { version = "0.8.0", default_features = false }
 emstr = { version = "0.2.0", default_features = false }
+heapless = "*"
 
 mc-core = { version = "4.1.0-pre0", default-features = false }
 ledger-mob-core = { path = "../core", default_features = false }
@@ -114,15 +115,18 @@ ledger-apdu = { path = "../vendor/rs/ledger-apdu" }
 
 # Mobilecoin core patches (replicates workspace level)
 
+mc-account-keys = { path = "../vendor/mob/account-keys" }
 mc-core = { path = "../vendor/mob/core" }
 mc-crypto-digestible = { path ="../vendor/mob/crypto/digestible" }
 mc-crypto-hashes = { path ="../vendor/mob/crypto/hashes" }
 mc-crypto-keys = { path ="../vendor/mob/crypto/keys" }
 mc-crypto-memo-mac = { path ="../vendor/mob/crypto/memo-mac" }
 mc-crypto-ring-signature = { path ="../vendor/mob/crypto/ring-signature" }
+mc-fog-sig-authority = { path = "../vendor/mob/fog/sig/authority" }
 mc-util-from-random = { path = "../vendor/mob/util/from-random" }
 mc-transaction-types = { path ="../vendor/mob/transaction/types" }
 mc-transaction-summary = { path ="../vendor/mob/transaction/summary" }
+mc-util-serial = { path = "../vendor/mob/util/serial" }
 
 # latest mbedtls needs spin `^0.9.4`, but `mc-util-vec-map` resolves spin to `^0.9.2` through `heapless` `^0.7`,
 # This specifies we use the latest version of heapless ~`0.9.4` to solve the dependency constraints. 

--- a/fw/nanox.json
+++ b/fw/nanox.json
@@ -9,7 +9,7 @@
   "linker": "rust-lld",
   "linker-flavor": "ld.lld",
   "llvm-target": "thumbv7m-none-eabi",
-  "atomic-cas": false,
+  "max-atomic-width": 32,
   "panic-strategy": "abort",
   "pre-link-args": {
       "ld.lld": [

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -15,7 +15,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use nanos_sdk::{
     buttons::ButtonEvent,
-    io::{self, Reply, SyscallError},
+    io::{self, ApduHeader, Reply, SyscallError},
     random::LedgerRng,
 };
 use nanos_ui::{
@@ -27,6 +27,7 @@ use ledger_mob_core::{
     apdu::{self, app_info::AppFlags},
     engine::{Engine, Error, Event, State},
 };
+use mc_core::consts::DEFAULT_SUBADDRESS_INDEX;
 
 mod consts;
 use consts::*;
@@ -91,7 +92,7 @@ extern "C" fn sample_main() {
         screen_update();
 
         loop {
-            let evt = comm.next_event::<u8>();
+            let evt = comm.next_event::<ApduHeader>();
 
             match evt {
                 io::Event::Button(LeftButtonRelease | RightButtonRelease | BothButtonsRelease) => {
@@ -110,7 +111,7 @@ extern "C" fn sample_main() {
 
     loop {
         // Wait for next event
-        let evt = comm.next_event();
+        let evt = comm.next_event::<ApduHeader>();
 
         // Handle input events and update UI state
         match &evt {
@@ -124,8 +125,8 @@ extern "C" fn sample_main() {
                 timeout = ticks.wrapping_add(TIMEOUT_S * TICKS_PER_S);
             }
             // Handle incoming APDUs
-            io::Event::Command(cmd) => {
-                if handle_apdu(engine, &mut comm, &mut ui, *cmd) {
+            io::Event::Command(hdr) => {
+                if handle_apdu(engine, &mut comm, &mut ui, hdr.ins) {
                     redraw = true;
                 }
             }
@@ -159,7 +160,30 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
 ) -> bool {
     // Handle buttons depending on UI state
     let r = match ui.state {
-        UiState::Menu => ui.menu.update(btn),
+        UiState::Menu => {
+            // Handle menu selections
+            ui.menu.update(btn).map_exit(|v| {
+                match v {
+                    MenuState::Address => {
+                        // Fetch subaddress from engine
+                        let s = engine.get_subaddress(0, DEFAULT_SUBADDRESS_INDEX);
+
+                        // Set UI state to display subaddress
+                        ui.state = UiState::Address(Address::new(
+                            &s.address,
+                            s.fog_id,
+                            s.fog_sig.as_ref().map(|s| s.as_slice()).unwrap_or(&[]),
+                        ));
+                    }
+                    MenuState::Version => ui.state = UiState::AppInfo(AppInfo::new()),
+                    MenuState::Exit => nanos_sdk::exit_app(0),
+                    _ => (),
+                }
+            });
+            // Force redraw
+            UiResult::Update
+        }
+        UiState::Address(ref mut a) => a.update(btn),
         UiState::KeyRequest(ref mut a) => {
             a.update(btn).map_exit(|v| {
                 // Unlock engine on approval
@@ -186,7 +210,7 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
         }
         #[cfg(feature = "summary")]
         UiState::TxSummaryRequest(ref mut a) => {
-            a.update(btn).map_exit(|v| {
+            a.update(btn, engine).map_exit(|v| {
                 // Approve or deny transaction
                 match *v {
                     true => engine.approve(),
@@ -209,14 +233,17 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
                 engine.reset()
             })
         }
+        UiState::AppInfo(ref mut a) => a.update(btn),
     };
 
     // Handle ui results
     match ui.state {
-        UiState::KeyRequest(..)
+        UiState::Address(..)
+        | UiState::KeyRequest(..)
         | UiState::TxRequest(..)
         | UiState::Progress(..)
         | UiState::Message(..)
+        | UiState::AppInfo(..)
             if r.is_exit() =>
         {
             ui.state = UiState::Menu;
@@ -337,8 +364,10 @@ fn handle_apdu<RNG: RngCore + CryptoRng>(
         State::Pending if !ui.state.is_tx_request() => match engine.report() {
             #[cfg(feature = "summary")]
             Some(r) => {
-                ui.state =
-                    UiState::TxSummaryRequest(TxSummaryApprover::new(r.balance_changes.len()));
+                ui.state = UiState::TxSummaryRequest(TxSummaryApprover::new(
+                    r.outputs.len(),
+                    r.totals.len(),
+                ));
                 render = true;
             }
             _ => {
@@ -406,7 +435,7 @@ fn platform_tests(comm: &mut io::Comm) {
         "EXIT?".place(Location::Bottom, Layout::Centered, false);
 
         loop {
-            let evt = comm.next_event::<u8>();
+            let evt = comm.next_event::<ApduHeader>();
 
             match evt {
                 io::Event::Button(_btn) => nanos_sdk::exit_app(30),

--- a/fw/src/ui/address.rs
+++ b/fw/src/ui/address.rs
@@ -1,0 +1,124 @@
+use core::str::from_utf8;
+
+use emstr::EncodeStr;
+use heapless::String;
+use rand_core::{CryptoRng, RngCore};
+
+use nanos_sdk::buttons::ButtonEvent;
+use nanos_ui::{
+    bagls::*,
+    layout::{Draw, Layout, Location, StringPlace},
+    screen_util,
+};
+
+use ledger_mob_core::{
+    engine::{Driver, Engine, FogId},
+    helpers::b58_encode_public_address,
+};
+use mc_core::account::PublicSubaddress;
+
+use super::{clear_screen, UiResult};
+
+/// Pager for rendering b58 encoded addresses
+#[derive(Clone, Debug, PartialEq)]
+pub struct Address<const N: usize> {
+    value: String<N>,
+    page: usize,
+    num_pages: usize,
+}
+
+const NUM_LINES: usize = 4;
+const LINE_LEN: usize = 16;
+
+const PAGE_LEN: usize = LINE_LEN * NUM_LINES;
+
+impl<const N: usize> Address<N> {
+    #[cfg_attr(feature = "noinline", inline(never))]
+    pub fn new(address: &PublicSubaddress, fog_id: FogId, fog_authority_sig: &[u8]) -> Self {
+        // Encode address to string
+        let value =
+            b58_encode_public_address::<N>(address, fog_id.url(), fog_authority_sig).unwrap();
+
+        // Compute number of pages for display
+        let num_pages = value.as_bytes().chunks(PAGE_LEN).count();
+
+        // Setup object
+        Self {
+            value,
+            num_pages,
+            page: 0,
+        }
+    }
+
+    pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<()> {
+        // Update paging based on button inputs
+        match btn {
+            // Exit on both buttons pressed/released
+            ButtonEvent::BothButtonsRelease => return UiResult::Exit(()),
+
+            // Page forward
+            ButtonEvent::RightButtonRelease if self.page < self.num_pages - 1 => self.page += 1,
+
+            // Page back
+            ButtonEvent::LeftButtonRelease if self.page > 0 => self.page -= 1,
+
+            // Otherwise, no change
+            _ => return UiResult::None,
+        }
+
+        UiResult::Update
+    }
+
+    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, _engine: &Engine<D, R>) {
+        // Clear screen
+        clear_screen();
+
+        // Show paging arrows
+        if self.page != 0 {
+            LEFT_ARROW.display();
+        }
+        if self.page < self.num_pages - 1 {
+            RIGHT_ARROW.display();
+        }
+
+        // Setup line buffer for display
+        let mut line_buff = [""; NUM_LINES + 1];
+
+        // Set title
+        let mut title_buff = [0u8; 20];
+        line_buff[0] = fmt_title("Address", self.page, self.num_pages, &mut title_buff);
+
+        // Write address line by line
+        let page = &self.value[self.page * PAGE_LEN..];
+        let mut rem = page.len().min(PAGE_LEN);
+
+        for i in 0..NUM_LINES {
+            if rem <= 0 {
+                continue;
+            }
+
+            let n = rem.min(LINE_LEN);
+            line_buff[i + 1] = &page[i * LINE_LEN..][..n];
+
+            rem -= n;
+        }
+
+        // Render lines
+        line_buff.place(Location::Middle, Layout::Centered, false);
+
+        // Update screen
+        screen_util::screen_update();
+    }
+}
+
+fn fmt_title<'a>(name: &str, index: usize, total: usize, buff: &'a mut [u8]) -> &'a str {
+    let n = match emstr::write!(&mut buff[..], name, "  (", index + 1, '/', total, ')') {
+        Ok(v) => v,
+        Err(_) => return "ENCODE_ERR",
+    };
+
+    match from_utf8(&buff[..n]) {
+        Ok(v) => v,
+        Err(_) => "INVALID_UTF8",
+    }
+}

--- a/fw/src/ui/app_info.rs
+++ b/fw/src/ui/app_info.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2022-2023 The MobileCoin Foundation
+
+use emstr::{helpers::Hex, EncodeStr};
+use rand_core::{CryptoRng, RngCore};
+
+use nanos_sdk::buttons::ButtonEvent;
+use nanos_ui::{
+    layout::{Layout, Location, StringPlace},
+    screen_util,
+};
+
+use ledger_mob_core::{
+    apdu::app_info::AppFlags,
+    engine::{Driver, Engine},
+};
+
+use super::{clear_screen, UiResult};
+use crate::consts::{app_flags, APP_VERSION, BUILD_TIME};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct AppInfo {}
+
+impl AppInfo {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn update(&mut self, btn: &ButtonEvent) -> UiResult {
+        match btn {
+            // Exit on both buttons pressed/released
+            ButtonEvent::BothButtonsRelease => UiResult::Exit(()),
+            // Otherwise, no change
+            _ => UiResult::None,
+        }
+    }
+
+    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, engine: &Engine<D, R>) {
+        let mut buff = [0u8; 32];
+
+        // Clear screen
+        clear_screen();
+
+        let state = engine.state();
+        let s = u16::from_be_bytes([state.state() as u8, state.value() as u8]);
+
+        let mut flags = app_flags();
+
+        if engine.is_unlocked() {
+            flags |= AppFlags::UNLOCKED;
+        }
+
+        let state_str = emstr::write!(
+            &mut buff[..],
+            "S: 0x",
+            Hex(&s.to_be_bytes()),
+            " F: 0x",
+            Hex(&flags.bits().to_be_bytes())
+        )
+        .map(|n| core::str::from_utf8(&buff[..n]));
+
+        let state_str = match state_str {
+            Ok(Ok(v)) => v,
+            _ => "INVALID_UTF8",
+        };
+
+        [APP_VERSION, BUILD_TIME, state_str].place(Location::Middle, Layout::Centered, false);
+
+        // Update screen
+        screen_util::screen_update();
+    }
+}

--- a/fw/src/ui/menu.rs
+++ b/fw/src/ui/menu.rs
@@ -1,32 +1,24 @@
 // Copyright (c) 2022-2023 The MobileCoin Foundation
 
-use emstr::{helpers::Hex, EncodeStr};
 use rand_core::{CryptoRng, RngCore};
 use strum::EnumCount;
 
-use mc_core::{account::RingCtAddress, consts::DEFAULT_SUBADDRESS_INDEX, subaddress::Subaddress};
-
 use nanos_sdk::buttons::ButtonEvent;
-
 use nanos_ui::{
     bagls::*,
     layout::{Draw, Layout, Location, StringPlace},
     screen_util,
 };
 
-use ledger_mob_core::{
-    apdu::app_info::AppFlags,
-    engine::{Driver, Engine},
-};
+use ledger_mob_core::engine::{Driver, Engine};
 
-use super::{clear_screen, helpers::*, UiResult};
-use crate::consts::{app_flags, APP_VERSION, BUILD_TIME, MOB32X32};
+use super::{clear_screen, UiResult};
+use crate::consts::MOB32X32;
 
 #[derive(Copy, Clone, Debug, PartialEq, EnumCount)]
 pub enum MenuState {
     Hello,
-    SpendAddress,
-    ViewAddress,
+    Address,
     Version,
     Exit,
 }
@@ -35,14 +27,11 @@ pub enum MenuState {
 pub struct UiMenu {
     // Current menu page index
     i: usize,
-    // Flag for menu page selection
-    selected: bool,
 }
 
 pub const MENU_STATES: &[MenuState] = &[
     MenuState::Hello,
-    MenuState::SpendAddress,
-    MenuState::ViewAddress,
+    MenuState::Address,
     MenuState::Version,
     MenuState::Exit,
 ];
@@ -60,23 +49,15 @@ impl UiMenu {
         MENU_STATES[self.i]
     }
 
-    pub fn update(&mut self, btn: &ButtonEvent) -> UiResult {
+    pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<MenuState> {
         // Menu button handling
         match (self.state(), btn) {
-            // Select on exit exits app
-            (MenuState::Exit, ButtonEvent::BothButtonsRelease) => nanos_sdk::exit_app(20),
-
-            // Select on home does nothing
-            (MenuState::Hello, ButtonEvent::BothButtonsRelease) => return UiResult::None,
-
-            // Otherwise, select enters / exits screens
-            (_, ButtonEvent::BothButtonsRelease) => {
-                self.selected = !self.selected;
-            }
+            // Otherwise, select enters screens
+            (_, ButtonEvent::BothButtonsRelease) => return UiResult::Exit(self.state()),
 
             // Scroll right and left in menu
-            (_, ButtonEvent::RightButtonRelease) if !self.selected => self.next(),
-            (_, ButtonEvent::LeftButtonRelease) if !self.selected => self.prev(),
+            (_, ButtonEvent::RightButtonRelease) => self.next(),
+            (_, ButtonEvent::LeftButtonRelease) => self.prev(),
 
             _ => return UiResult::None,
         }
@@ -84,75 +65,29 @@ impl UiMenu {
         UiResult::Update
     }
 
-    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, engine: &Engine<D, R>) {
-        let mut buff = [0u8; 32];
+    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, _engine: &Engine<D, R>) {
         let state = self.state();
 
         // Clear screen
         clear_screen();
 
         // Show arrows on menu pages
-        if !self.selected {
-            LEFT_ARROW.display();
-            RIGHT_ARROW.display();
-        }
+        LEFT_ARROW.display();
+        RIGHT_ARROW.display();
 
         // Render pages
-        match (state, self.selected) {
-            (MenuState::Hello, _) => {
+        match state {
+            MenuState::Hello => {
                 "M O B I L E C O I N".place(Location::Custom(8), Layout::Centered, false);
                 MOB32X32.draw((128 - 32) / 2, 24);
             }
-            (MenuState::SpendAddress, false) => {
-                "Spend Subaddress".place(Location::Middle, Layout::Centered, false);
+            MenuState::Address => {
+                "Address".place(Location::Middle, Layout::Centered, false);
             }
-            (MenuState::SpendAddress, true) => {
-                let default_subaddress = engine.get_account(0).subaddress(DEFAULT_SUBADDRESS_INDEX);
-                let key = default_subaddress.spend_public_key();
-                show_key("Spend Subaddress", &key.to_bytes());
-            }
-            (MenuState::ViewAddress, false) => {
-                "View Subaddress".place(Location::Middle, Layout::Centered, false);
-            }
-            (MenuState::ViewAddress, true) => {
-                let default_subaddress = engine.get_account(0).subaddress(DEFAULT_SUBADDRESS_INDEX);
-                let key = default_subaddress.view_public_key();
-                show_key("View Subaddress", &key.to_bytes());
-            }
-            (MenuState::Version, false) => {
+            MenuState::Version => {
                 "App Info".place(Location::Middle, Layout::Centered, false);
             }
-            (MenuState::Version, true) => {
-                let state = engine.state();
-                let s = u16::from_be_bytes([state.state() as u8, state.value() as u8]);
-
-                let mut flags = app_flags();
-
-                if engine.is_unlocked() {
-                    flags |= AppFlags::UNLOCKED;
-                }
-
-                let state_str = emstr::write!(
-                    &mut buff[..],
-                    "S: 0x",
-                    Hex(&s.to_be_bytes()),
-                    " F: 0x",
-                    Hex(&flags.bits().to_be_bytes())
-                )
-                .map(|n| core::str::from_utf8(&buff[..n]));
-
-                let state_str = match state_str {
-                    Ok(Ok(v)) => v,
-                    _ => "INVALID_UTF8",
-                };
-
-                [APP_VERSION, BUILD_TIME, state_str].place(
-                    Location::Middle,
-                    Layout::Centered,
-                    false,
-                );
-            }
-            (MenuState::Exit, _) => "Exit".place(Location::Middle, Layout::Centered, false),
+            MenuState::Exit => "Exit".place(Location::Middle, Layout::Centered, false),
         }
 
         // Update screen

--- a/fw/src/ui/mod.rs
+++ b/fw/src/ui/mod.rs
@@ -25,6 +25,12 @@ pub use message::*;
 mod tx_blind_approver;
 pub use tx_blind_approver::*;
 
+mod address;
+pub use address::*;
+
+mod app_info;
+pub use app_info::*;
+
 #[cfg(feature = "summary")]
 mod tx_summary_approver;
 #[cfg(feature = "summary")]
@@ -44,10 +50,13 @@ pub struct Ui {
     pub menu: UiMenu,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum UiState {
     /// Showing main menu
     Menu,
+
+    /// Showing a b58 address
+    Address(Address<512>),
 
     /// Request for view keys, awaiting user input
     KeyRequest(Approver),
@@ -67,6 +76,9 @@ pub enum UiState {
 
     /// Messages (transaction complete, rejected, etc.)
     Message(Message),
+
+    /// App information
+    AppInfo(AppInfo),
 }
 
 impl UiState {
@@ -109,8 +121,9 @@ impl Ui {
     /// Render the [Ui] using the current state
     #[inline(never)]
     pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, engine: &Engine<D, R>) {
-        match self.state {
+        match &self.state {
             UiState::Menu => self.menu.render(engine),
+            UiState::Address(a) => a.render(engine),
             UiState::KeyRequest(a) => a.render(engine),
             UiState::TxRequest(a) => a.render(engine),
             #[cfg(feature = "summary")]
@@ -119,6 +132,7 @@ impl Ui {
             UiState::IdentRequest(a) => a.render(engine),
             UiState::Progress(a) => a.render(engine),
             UiState::Message(a) => a.render(engine),
+            UiState::AppInfo(a) => a.render(engine),
         }
     }
 }

--- a/fw/src/ui/tx_summary_approver.rs
+++ b/fw/src/ui/tx_summary_approver.rs
@@ -17,45 +17,57 @@ use nanos_ui::{
 
 use ledger_mob_core::{
     engine::{Driver, Engine, TransactionEntity},
-    helpers::fmt_token_val,
+    helpers::{b58_encode_public_address, fmt_token_val},
 };
 
 use super::{
     clear_screen,
     helpers::{tx_approve_page, tx_deny_page},
-    UiResult,
+    Address, UiResult,
 };
 
 /// UI Approval Element
 ///
 /// Used for user-confirmation of key requests (and transactions, pending TxSummary availability)
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TxSummaryApprover {
-    op_count: usize,
+    num_outputs: usize,
+    num_totals: usize,
     state: TxSummaryApproverState,
+    selected: bool,
+    address: Option<Address<512>>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Display, EnumCount)]
-pub enum TxSummaryApproverState {
+enum TxSummaryApproverState {
     Init,
     Op(usize),
     Fee,
+    Total(usize),
     Allow,
     Deny,
 }
 
 impl TxSummaryApprover {
     /// Create a new Approver with the provided message
-    pub fn new(op_count: usize) -> Self {
+    pub fn new(num_outputs: usize, num_totals: usize) -> Self {
         Self {
-            op_count,
+            num_outputs,
+            num_totals,
             state: TxSummaryApproverState::Init,
+            selected: false,
+            address: None,
         }
     }
 
     /// Update [Approver] state, handling button events and returning the
     /// approval state on exit
-    pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<bool> {
+    #[cfg_attr(feature = "noinline", inline(never))]
+    pub fn update<D: Driver, R: RngCore + CryptoRng>(
+        &mut self,
+        btn: &ButtonEvent,
+        engine: &Engine<D, R>,
+    ) -> UiResult<bool> {
         use ButtonEvent::*;
         use TxSummaryApproverState::*;
 
@@ -63,18 +75,60 @@ impl TxSummaryApprover {
             // Transaction overview (first page)
             (Init, RightButtonRelease) => self.state = Op(0),
 
+            // Passthrough to address renderer if available
+            (Op(_), BothButtonsRelease) if self.address.is_some() => self.address = None,
+            (Op(_), _) if self.address.is_some() => {
+                let address = self.address.as_mut().unwrap();
+                address.update(btn).map_exit(|_| ());
+            }
+
             // List of operations
             (Op(n), LeftButtonRelease) if n == 0 => self.state = Init,
             (Op(n), LeftButtonRelease) => self.state = Op(n - 1),
-            (Op(n), RightButtonRelease) if n + 1 < self.op_count => self.state = Op(n + 1),
+            (Op(n), RightButtonRelease) if n + 1 < self.num_outputs => self.state = Op(n + 1),
             (Op(_n), RightButtonRelease) => self.state = Fee,
 
+            // Select for operations with addresses
+            (Op(n), BothButtonsRelease) if self.address.is_none() => {
+                let report = match engine.report() {
+                    Some(r) => r,
+                    None => return UiResult::None,
+                };
+
+                let h = match &report.outputs[n].0 {
+                    TransactionEntity::OurAddress(h) => h,
+                    TransactionEntity::OtherAddress(h) => h,
+                    _ => return UiResult::None,
+                };
+
+                // Resolve address from short hash
+                let s = match engine.address(&h) {
+                    Some(a) => a,
+                    None => return UiResult::None,
+                };
+
+                // Setup address for rendering
+                self.address = Some(Address::new(
+                    &s.address,
+                    s.fog_id,
+                    s.fog_sig.as_ref().map(|s| s.as_slice()).unwrap_or(&[]),
+                ));
+
+                return UiResult::Update;
+            }
+
             // Fee information
-            (Fee, LeftButtonRelease) => self.state = Op(self.op_count - 1),
-            (Fee, RightButtonRelease) => self.state = Allow,
+            (Fee, LeftButtonRelease) => self.state = Op(self.num_outputs - 1),
+            (Fee, RightButtonRelease) => self.state = Total(0),
+
+            // List of totals
+            (Total(n), LeftButtonRelease) if n == 0 => self.state = Fee,
+            (Total(n), LeftButtonRelease) => self.state = Total(n - 1),
+            (Total(n), RightButtonRelease) if n + 1 < self.num_totals => self.state = Total(n + 1),
+            (Total(_n), RightButtonRelease) => self.state = Allow,
 
             // Approve page
-            (Allow, LeftButtonRelease) => self.state = Fee,
+            (Allow, LeftButtonRelease) => self.state = Total(self.num_totals - 1),
             (Allow, BothButtonsRelease) => return UiResult::Exit(true),
             (Allow, RightButtonRelease) => self.state = Deny,
 
@@ -124,35 +178,66 @@ impl TxSummaryApprover {
             Init => {
                 ["Transaction", "Request"].place(Location::Middle, Layout::Centered, false);
             }
+            Op(_n) if self.address.is_some() => {
+                let address = self.address.as_ref().unwrap();
+                address.render(engine);
+            }
             Op(n) => {
                 // Fetch balance change information
-                let (kind, value) = report.balance_changes.index(n).unwrap();
+                let (entity, token_id, value) = &report.outputs[n];
 
                 // Write value and token id
                 // TODO: ensure values can not be concatenated
 
-                let value_str = fmt_token_val(*value, kind.1, &mut value_buff);
+                let value_str = fmt_token_val(*value as i64, *token_id, &mut value_buff);
 
-                match &kind.0 {
-                    // Balance changes
-                    TransactionEntity::Ourself => {
-                        let title_str = fmt_page("Balance", n, self.op_count, &mut title_buff);
-                        [title_str, value_str].place(Location::Middle, Layout::Centered, false);
-                    }
-                    // Send value + address
-                    TransactionEntity::Address(a) => {
-                        let title_str = fmt_page("Send", n, self.op_count, &mut title_buff);
-                        let addr_str = fmt_addr(a.as_ref(), &mut buff);
+                match &entity {
+                    // Balance changes to ourself or others
+                    TransactionEntity::OurAddress(a) | TransactionEntity::OtherAddress(a) => {
+                        // Switch heading depending on whether this is
+                        // to an address we control
+                        let heading = match &entity {
+                            TransactionEntity::OurAddress(_) => "Receive",
+                            TransactionEntity::OtherAddress(_) => "Send",
+                            _ => unreachable!(),
+                        };
 
-                        [title_str, value_str, addr_str].place(
+                        DOWN_ARROW.shift_h(-60).shift_v(24).display();
+
+                        let title_str = fmt_page(heading, n, self.num_outputs, &mut title_buff);
+
+                        // Lookup address from cache
+                        let addr_str = match engine.address(a) {
+                            Some(c) => {
+                                // Encode in b58 form for display
+                                let b58 = b58_encode_public_address::<512>(
+                                    &c.address,
+                                    c.fog_id.url(),
+                                    c.fog_sig.as_ref().map(|v| &v[..]).unwrap_or(&[]),
+                                );
+
+                                // Write to display string
+                                match b58 {
+                                    Ok(v) => fmt_b58_addr(&v, &mut buff),
+                                    Err(_) => "B58 ENCODE ERROR",
+                                }
+                            }
+                            // If we don't have a cache match, display short hash
+                            // NOTE: this _shouldn't_ be possible so long
+                            // as the cache size is the same as the report size
+                            None => fmt_short_hash(a.as_ref(), &mut buff),
+                        };
+
+                        // Display title / value / address
+                        [title_str, value_str, addr_str, ""].place(
                             Location::Middle,
                             Layout::Centered,
                             false,
                         );
                     }
-                    // Swaps
+                    // Swap outputs
                     TransactionEntity::Swap => {
-                        let title_str = fmt_page("Swap", n, self.op_count, &mut buff);
+                        let title_str = fmt_page("Swap", n, self.num_outputs, &mut buff);
                         [title_str, value_str].place(Location::Middle, Layout::Centered, false);
                     }
                 }
@@ -165,6 +250,15 @@ impl TxSummaryApprover {
                     &mut buff[..],
                 );
                 ["Fee", value_str].place(Location::Middle, Layout::Centered, false);
+            }
+            // Totals
+            Total(n) => {
+                // Fetch total information
+                let (token_id, value) = &report.totals[n];
+
+                let value_str = fmt_token_val(*value, *token_id, &mut value_buff);
+                let title_str = fmt_page("Total", n, self.num_totals, &mut title_buff);
+                [title_str, value_str].place(Location::Middle, Layout::Centered, false);
             }
             Deny => {
                 tx_deny_page();
@@ -190,12 +284,26 @@ fn fmt_page<'a>(name: &str, index: usize, total: usize, buff: &'a mut [u8]) -> &
     }
 }
 
-fn fmt_addr<'a>(addr: &[u8], buff: &'a mut [u8]) -> &'a str {
+fn fmt_b58_addr<'a>(addr: &str, buff: &'a mut [u8]) -> &'a str {
+    let n = match emstr::write!(&mut buff[..], &addr[..8], "...", &addr[addr.len() - 8..]) {
+        Ok(v) => v,
+        Err(_) => return "ENCODE_ERR",
+    };
+
+    match from_utf8(&buff[..n]) {
+        Ok(v) => v,
+        Err(_) => "INVALID_UTF8",
+    }
+}
+
+fn fmt_short_hash<'a>(addr: &[u8], buff: &'a mut [u8]) -> &'a str {
     let n = match emstr::write!(
         &mut buff[..],
+        "(",
         Hex(&addr[..4]),
         "...",
-        Hex(&addr[addr.len() - 4..])
+        Hex(&addr[addr.len() - 4..]),
+        ")"
     ) {
         Ok(v) => v,
         Err(_) => return "ENCODE_ERR",

--- a/fw/src/ui/tx_summary_approver.rs
+++ b/fw/src/ui/tx_summary_approver.rs
@@ -102,7 +102,7 @@ impl TxSummaryApprover {
                 };
 
                 // Resolve address from short hash
-                let s = match engine.address(&h) {
+                let s = match engine.address(h) {
                     Some(a) => a,
                     None => return UiResult::None,
                 };

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.4.0"
 heapless = "0.8.0"
 rand = "*"
 rand_core = "0.6.3"
-serde = "*"
+serde = "1.0.144"
 serde_json = "*"
 tiny-bip39 = "1.0"
 

--- a/tests/src/transaction.rs
+++ b/tests/src/transaction.rs
@@ -131,7 +131,7 @@ where
                 &summary,
                 &unblinding,
                 account.view_private_key().clone().inner(),
-                &PublicSubaddress::from(&change),
+                PublicSubaddress::from(&change),
             )
             .unwrap();
 

--- a/tests/src/transaction.rs
+++ b/tests/src/transaction.rs
@@ -2,7 +2,12 @@
 
 use bip39::Mnemonic;
 use log::{debug, error, info, trace};
-use mc_core::{account::Account, slip10::Slip10KeyGenerator};
+use mc_core::{
+    account::{Account, PublicSubaddress},
+    consts::CHANGE_SUBADDRESS_INDEX,
+    slip10::Slip10KeyGenerator,
+    subaddress::Subaddress,
+};
 use mc_transaction_summary::verify_tx_summary;
 use rand_core::OsRng;
 use std::future::Future;
@@ -73,6 +78,7 @@ where
 {
     // Load account and unsigned transaction
     let account = tx.account();
+    let change = account.subaddress(CHANGE_SUBADDRESS_INDEX);
     let req = tx.tx_req();
 
     trace!("Request: {:?}", req);
@@ -125,6 +131,7 @@ where
                 &summary,
                 &unblinding,
                 account.view_private_key().clone().inner(),
+                &PublicSubaddress::from(&change),
             )
             .unwrap();
 


### PR DESCRIPTION
per #20 

- adds `prost` with a minimal proto file reproducing of `PrintableWrapper` (avoiding grpc components of `mc-api`)
- adds `FogId`s to summary messages as a compressed alternative to fog URLs, removes `ShortAddressHash` as this is now derived on device
- adds helpers for `ShortAddressHash` derivation from primitive types w/ tests against `mc-account-keys` types
- adds helpers for b58 encoding from primitive types w/ tests against `mc-account-keys` types
- updates to new summary reports w/ caching for address resolution
- updates summary view with subpages showing b58 addresses
- replaces key views with b58 encoded address view

this is more alloc heavy than would be ideal, but, cannot currently be avoided due to `prost`. we also can't sign fog authorities at the moment as the CSPRNG uses 10kb of stack all by itself, which is non-critical but should be addressed so we can display generated addresses in a manner consistent with the upstream app.

tested running on the nanosplus, _may_ need atomic polyfill for nanox depending on the outcome of #27 