### PR TITLE
fix: further stack reductions for nanox support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION=$(shell git describe --dirty=+)
 NANOSP_ARGS=
 NANOX_ARGS=
 
-SPECULOS_ARGS=--zoom=4
+SPECULOS_ARGS=--zoom=4 -t
 ifdef MNEMONIC
 	SPECULOS_ARGS+=--seed "$(MNEMONIC)"
 endif
@@ -90,10 +90,10 @@ objdump:
 	arm-none-eabi-objdump fw/target/nanosplus/release/ledger-mob-fw --disassemble=sample_main -S | head -n 20
 
 wts-nanosplus:
-	wts fw/target/nanosplus/release/ledger-mob-fw -n 15
+	wts fw/target/nanosplus/release/ledger-mob-fw -n 20
 
 wts-nanox:
-	wts fw/target/nanox/release/ledger-mob-fw -n 15
+	wts fw/target/nanox/release/ledger-mob-fw -n 20
 
 # Run linters
 lint: fmt clippy

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION=$(shell git describe --dirty=+)
 NANOSP_ARGS=
 NANOX_ARGS=
 
-SPECULOS_ARGS=--zoom=4 -t
+SPECULOS_ARGS=--zoom=4
 ifdef MNEMONIC
 	SPECULOS_ARGS+=--seed "$(MNEMONIC)"
 endif
@@ -79,11 +79,11 @@ speculos:
 
 # Run firmware under speculos with QEMU debug connection
 nanosplus-debug:
-	cd fw && speculos.py --model nanosp --display qt -k 1.0 --apdu-port 1237 --seed="$(MNEMONIC)" -d target/nanosplus/release/ledger-mob-fw
+	cd fw && speculos.py --model nanosp --display qt -a 1 --apdu-port 1237 $(SPECULOS_ARGS) -d target/nanosplus/release/ledger-mob-fw
 
 # Launch GDB connecting to speculos QEMU
 nanosplus-gdb:
-	cd fw && rust-gdb --tui fw/target/nanosplus/debug/ledger-mob-fw
+	cd fw && rust-gdb fw/target/nanosplus/release/ledger-mob-fw
 
 # Objdump to show disassembly of sample_main (see `sp` for stack allocation)
 objdump:

--- a/apdu/src/state.rs
+++ b/apdu/src/state.rs
@@ -82,6 +82,7 @@ impl Digest {
     }
 
     /// Reset state digest from random seed
+    #[inline(never)]
     pub fn from_random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut b = [0u8; 32];
         rng.fill_bytes(&mut b);
@@ -96,6 +97,7 @@ impl Digest {
     // TODO: what if we apply an event but lose the response, will the client retry..?
     // TODO: swap to tree approach, cache prior event and skip updates to allow retries
     // TODO: could use [Digestible], though this adds dependencies for implementers?
+    #[inline(never)]
     pub fn update(&mut self, evt: &[u8; 32]) -> &Self {
         // Build and update digest
         let mut d = Sha512_256::new();

--- a/core/src/engine/digest.rs
+++ b/core/src/engine/digest.rs
@@ -53,6 +53,7 @@ impl TxDigest {
     }
 
     /// Reset transaction digest with from random seed
+    #[inline(never)]
     pub fn from_random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut b = [0u8; 32];
         rng.fill_bytes(&mut b);
@@ -64,9 +65,10 @@ impl TxDigest {
     }
 
     /// Update transaction digest with new event
-    // TODO: what if we apply an event but lose the response, will the client retry..?
+    // TODO: what if we apply an event but lose the response, should the client retry..?
     // TODO: swap to tree approach, cache prior event and skip updates to allow retries
     // TODO: could use [Digestible], though this adds dependencies for implementers?
+    #[inline(never)]
     pub fn update(&mut self, evt: &Event) -> &Self {
         // Build and update digest
         let mut d = Sha512_256::new();

--- a/core/src/engine/digest.rs
+++ b/core/src/engine/digest.rs
@@ -67,7 +67,7 @@ impl TxDigest {
     // TODO: what if we apply an event but lose the response, will the client retry..?
     // TODO: swap to tree approach, cache prior event and skip updates to allow retries
     // TODO: could use [Digestible], though this adds dependencies for implementers?
-    pub fn update(&mut self, evt: &Event<'_>) -> &Self {
+    pub fn update(&mut self, evt: &Event) -> &Self {
         // Build and update digest
         let mut d = Sha512_256::new();
 

--- a/core/src/engine/function.rs
+++ b/core/src/engine/function.rs
@@ -200,6 +200,7 @@ impl Function {
 
     /// Initialise identity function
     #[cfg(feature = "ident")]
+    #[cfg_attr(feature = "noinline", inline(never))]
     pub fn ident_init(
         &mut self,
         identity_index: u32,
@@ -229,6 +230,7 @@ impl Function {
     }
 
     /// Clear context, executing drop if required
+    #[cfg_attr(feature = "noinline", inline(never))]
     pub fn clear(&mut self) {
         match &mut self.inner {
             #[cfg(feature = "mlsag")]

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -957,10 +957,10 @@ mod test {
         pub static ref PRIVATE_KEY: RistrettoPrivate = RistrettoPrivate::from_random(&mut OsRng{});
 
         /// Mocked out test values, only for state tests
-        pub static ref TESTS: [(State, Event<'static>); 4] = [
+        pub static ref TESTS: [(State, Event); 4] = [
             (State::Init, Event::TxInit{ account_index: 0, num_rings: 13 }),
 
-            (State::SetMessage, Event::TxSetMessage(&[0xaa, 0xbb, 0xcc])),
+            (State::SetMessage, Event::TxSetMessage(heapless::Vec::from_slice(&[0xaa, 0xbb, 0xcc]).unwrap())),
 
             (State::Ready, Event::TxRingInit{ ring_size: RING_SIZE as u8, value: 100, token_id: 10, real_index: 3, subaddress_index: 8, onetime_private_key: None }),
 
@@ -1138,7 +1138,7 @@ mod test {
         };
 
         // Set message (shared between rings)
-        let evt = Event::TxSetMessage(&params.message);
+        let evt = Event::TxSetMessage(heapless::Vec::from_slice(&params.message).unwrap());
         let r = engine.update(&evt).expect("Set message");
 
         assert_eq!(

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -609,8 +609,8 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
         );
 
         Output::KeyImage {
-            account_index: account_index,
-            subaddress_index: subaddress_index,
+            account_index,
+            subaddress_index,
             key_image: KeyImage::from(&onetime_private_key),
         }
     }

--- a/core/src/engine/output.rs
+++ b/core/src/engine/output.rs
@@ -87,6 +87,8 @@ pub enum Output {
 
 impl Output {
     /// Initialise an [Output] pointer without allocation
+    /// # Safety
+    /// This is safe as long as the pointer is valid
     pub unsafe fn init(ptr: *mut Self) {
         ptr.write(Output::None);
     }

--- a/core/src/engine/output.rs
+++ b/core/src/engine/output.rs
@@ -86,6 +86,11 @@ pub enum Output {
 }
 
 impl Output {
+    /// Initialise an [Output] pointer without allocation
+    pub unsafe fn init(ptr: *mut Self) {
+        ptr.write(Output::None);
+    }
+
     /// Encode an [`Output`] object to a response [APDU]
     #[cfg_attr(feature = "noinline", inline(never))]
     pub fn encode(&self, buff: &mut [u8]) -> Result<usize, ApduError> {

--- a/core/src/engine/ring.rs
+++ b/core/src/engine/ring.rs
@@ -160,7 +160,7 @@ impl RingSigner {
     #[cfg_attr(feature = "noinline", inline(never))]
     pub fn update(
         &mut self,
-        evt: &Event<'_>,
+        evt: &Event,
         rng: impl RngCore + CryptoRng,
     ) -> Result<(RingState, Output), Error> {
         #[cfg(feature = "log")]

--- a/fw/.gdbinit
+++ b/fw/.gdbinit
@@ -2,6 +2,6 @@ set architecture arm
 target remote 127.0.0.1:1234
 handle SIGILL nostop pass noprint
 add-symbol-file "../vendor/speculos/build/src/launcher" 0xf00001c0
-add-symbol-file "target/nanosplus/debug/ledger-mob-fw" 0x40000000
+add-symbol-file "target/nanosplus/release/ledger-mob-fw" 0x40000000
 b sample_main
 c

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "2.0.0-pre.0"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=2931c688eb11341a1145e257bc41d8ecbe36277c#2931c688eb11341a1145e257bc41d8ecbe36277c"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -2189,11 +2190,3 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "mc-account-keys"
-version = "4.1.0-pre0"
-
-[[patch.unused]]
-name = "mc-util-serial"
-version = "4.1.0-pre0"

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -456,7 +456,6 @@ dependencies = [
 [[package]]
 name = "ed25519-dalek"
 version = "2.0.0-pre.0"
-source = "git+https://github.com/dalek-cryptography/ed25519-dalek.git?rev=2931c688eb11341a1145e257bc41d8ecbe36277c#2931c688eb11341a1145e257bc41d8ecbe36277c"
 dependencies = [
  "curve25519-dalek",
  "ed25519",

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -104,7 +104,8 @@ lto = 'fat'
 
 
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "99c0520aa79401b69fb51d38172cd58c6a256cfb" }
-ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
+ed25519-dalek = { path = "../../ed25519-dalek" }
+#ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
 x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "4fbaa3343301c62cfdbc3023c9f485257e6b718a" }
 
 # Fork and rename to use "OG" dalek-cryptography.

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -104,8 +104,7 @@ lto = 'fat'
 
 
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "99c0520aa79401b69fb51d38172cd58c6a256cfb" }
-ed25519-dalek = { path = "../../ed25519-dalek" }
-#ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }
 x25519-dalek = { git = "https://github.com/mobilecoinfoundation/x25519-dalek.git", rev = "4fbaa3343301c62cfdbc3023c9f485257e6b718a" }
 
 # Fork and rename to use "OG" dalek-cryptography.
@@ -116,7 +115,6 @@ ledger-apdu = { path = "../vendor/rs/ledger-apdu" }
 
 # Mobilecoin core patches (replicates workspace level)
 
-mc-account-keys = { path = "../vendor/mob/account-keys" }
 mc-core = { path = "../vendor/mob/core" }
 mc-crypto-digestible = { path ="../vendor/mob/crypto/digestible" }
 mc-crypto-hashes = { path ="../vendor/mob/crypto/hashes" }
@@ -127,7 +125,6 @@ mc-fog-sig-authority = { path = "../vendor/mob/fog/sig/authority" }
 mc-util-from-random = { path = "../vendor/mob/util/from-random" }
 mc-transaction-types = { path ="../vendor/mob/transaction/types" }
 mc-transaction-summary = { path ="../vendor/mob/transaction/summary" }
-mc-util-serial = { path = "../vendor/mob/util/serial" }
 
 # patch nanos_sdk so nanos_ui uses the same version
 # hack to avoid cargo#5478 https://github.com/rust-lang/cargo/issues/5478

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -25,7 +25,7 @@ use nanos_ui::{
 
 use ledger_mob_core::{
     apdu::{self, app_info::AppFlags},
-    engine::{Engine, Error, Event, State, Output},
+    engine::{Engine, Error, Event, Output, State},
 };
 use mc_core::consts::DEFAULT_SUBADDRESS_INDEX;
 
@@ -469,4 +469,3 @@ fn platform_tests(comm: &mut io::Comm) {
         drop(v);
     }
 }
-

--- a/fw/src/platform.rs
+++ b/fw/src/platform.rs
@@ -105,5 +105,7 @@ pub extern "C" fn print_stack() {
     let s = 30720 - (a & 0xFFFF);
 
     // Set context for a syscall, allows this to be printed under speculos
-    unsafe { nanos_sdk::bindings::try_context_set( s as *mut try_context_s ); }
+    unsafe {
+        nanos_sdk::bindings::try_context_set(s as *mut try_context_s);
+    }
 }

--- a/fw/src/ui/menu.rs
+++ b/fw/src/ui/menu.rs
@@ -37,6 +37,10 @@ pub const MENU_STATES: &[MenuState] = &[
 ];
 
 impl UiMenu {
+    pub const fn new() -> Self {
+        Self { i: 0 }
+    }
+
     fn next(&mut self) {
         self.i = (self.i + 1) % MENU_STATES.len()
     }

--- a/fw/src/ui/mod.rs
+++ b/fw/src/ui/mod.rs
@@ -111,10 +111,10 @@ impl UiState {
 
 impl Ui {
     /// Create a new [Ui] instance
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             state: UiState::Menu,
-            menu: UiMenu::default(),
+            menu: UiMenu::new(),
         }
     }
 

--- a/fw/src/ui/mod.rs
+++ b/fw/src/ui/mod.rs
@@ -118,6 +118,11 @@ impl Ui {
         }
     }
 
+    /// Initialise a UI instance without double stack allocations
+    pub unsafe fn init(p: *mut Self) {
+        core::ptr::write(p, Self::new());
+    }
+
     /// Render the [Ui] using the current state
     #[inline(never)]
     pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, engine: &Engine<D, R>) {


### PR DESCRIPTION
it turns out the nanox has a more severe stack use limitation, faulting on -memory access- when the stack pointer exceeds 8k, rather than only when invoking syscalls on the nanosplus.

it is expected that this limit will be resolved in future firmware, for now we should be able to avoid the issue by pre-allocating and using out-pointer tricks to avoid rust's lack of working copy elision / NRVO.

following #23, this PR:
- refactors events to be self contained (simplifying passing these by reference)
- moves ui, event, and object storage to the heap w/ pointer-based initialisation
- splits out identity and key image functions so these can no-longer be inlined in `Engine::update`

this reduces our worst-case stack depth by ~2k down to ~7524 bytes which appears to get us under the limit on the nanox. this seems to be okay in the simulator, however, needs to be validated on an actual device.
