### PR TITLE
Add settings page for fog selection

### DIFF
--- a/apdu/src/tx/summary.rs
+++ b/apdu/src/tx/summary.rs
@@ -309,6 +309,15 @@ const FOG_SIGNAL_MAINNET_URI: &str = "fog://fog-rpt-prd.namda.net";
 
 /// TODO: support old signal fog URLs
 
+/// List of supported fogs for iteration and display
+pub const FOG_IDS: &[FogId] = &[
+    FogId::None,
+    FogId::MobMain,
+    FogId::MobTest,
+    FogId::SignalMain,
+    FogId::SignalTest,
+];
+
 impl Encode for FogId {
     type Error = encdec::Error;
 
@@ -714,5 +723,13 @@ mod test {
 
         let mut buff = [0u8; 256];
         encode_decode_apdu(&mut buff, &apdu);
+    }
+
+    /// Ensure [FogId] enum values match order of [FOG_ID] list
+    #[test]
+    fn fog_id_match() {
+        for (i, f) in FOG_IDS.iter().enumerate() {
+            assert_eq!(i, *f as usize);
+        }
     }
 }

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -478,12 +478,14 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
 
     /// Fetch a Subaddress instance for a given wallet and subaddress index
     #[cfg_attr(feature = "noinline", inline(never))]
-    pub fn get_subaddress(&self, account_index: u32, subaddress_index: u64) -> OutputAddress {
+    pub fn get_subaddress(
+        &self,
+        account_index: u32,
+        subaddress_index: u64,
+        fog_id: FogId,
+    ) -> OutputAddress {
         let account = self.get_account(account_index);
         let s = account.subaddress(subaddress_index);
-
-        // TODO: Enable FogId selection when stack issue with HC-128 is resolved
-        let fog_id = FogId::MobTest;
 
         let sig: Option<[u8; 64]> = match fog_id {
             FogId::None => None,

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -29,6 +29,7 @@ memo = [ "ledger-mob-core/memo" ]
 ident = [ "ledger-mob-core/ident" ]
 summary = [ "alloc", "ledger-mob-core/summary" ]
 pre-release = []
+nvm = []
 
 alloc = [ "embedded-alloc", "critical-section", "ledger-mob-core/alloc" ]
 noinline = [ "ledger-mob-core/noinline" ]

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -189,6 +189,10 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
                         ));
                     }
                     MenuState::Version => ui.state = UiState::AppInfo(AppInfo::new()),
+                    MenuState::Settings => {
+                        let fog_id = platform_get_fog_id();
+                        ui.state = UiState::Settings(Settings::new(fog_id))
+                    },
                     MenuState::Exit => nanos_sdk::exit_app(0),
                     _ => (),
                 }
@@ -247,6 +251,10 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
             })
         }
         UiState::AppInfo(ref mut a) => a.update(btn),
+        UiState::Settings(ref mut a) => a.update(btn).map_exit(|fog_id| {
+            // Update fog id
+            platform_set_fog_id(fog_id);
+        }),
     };
 
     // Handle ui results
@@ -257,6 +265,7 @@ fn handle_btn<RNG: RngCore + CryptoRng>(
         | UiState::Progress(..)
         | UiState::Message(..)
         | UiState::AppInfo(..)
+        | UiState::Settings(..)
             if r.is_exit() =>
         {
             ui.state = UiState::Menu;

--- a/fw/src/ui/menu.rs
+++ b/fw/src/ui/menu.rs
@@ -20,6 +20,7 @@ pub enum MenuState {
     Hello,
     Address,
     Version,
+    Settings,
     Exit,
 }
 
@@ -33,6 +34,7 @@ pub const MENU_STATES: &[MenuState] = &[
     MenuState::Hello,
     MenuState::Address,
     MenuState::Version,
+    MenuState::Settings,
     MenuState::Exit,
 ];
 
@@ -90,6 +92,9 @@ impl UiMenu {
             }
             MenuState::Version => {
                 "App Info".place(Location::Middle, Layout::Centered, false);
+            }
+            MenuState::Settings => {
+                "Settings".place(Location::Middle, Layout::Centered, false);
             }
             MenuState::Exit => "Exit".place(Location::Middle, Layout::Centered, false),
         }

--- a/fw/src/ui/mod.rs
+++ b/fw/src/ui/mod.rs
@@ -31,6 +31,9 @@ pub use address::*;
 mod app_info;
 pub use app_info::*;
 
+mod settings;
+pub use settings::*;
+
 #[cfg(feature = "summary")]
 mod tx_summary_approver;
 #[cfg(feature = "summary")]
@@ -79,6 +82,9 @@ pub enum UiState {
 
     /// App information
     AppInfo(AppInfo),
+
+    /// Settings
+    Settings(Settings),
 }
 
 impl UiState {
@@ -138,6 +144,7 @@ impl Ui {
             UiState::Progress(a) => a.render(engine),
             UiState::Message(a) => a.render(engine),
             UiState::AppInfo(a) => a.render(engine),
+            UiState::Settings(a) => a.render(engine),
         }
     }
 }

--- a/fw/src/ui/settings.rs
+++ b/fw/src/ui/settings.rs
@@ -1,0 +1,88 @@
+//! Settings page for application UI
+//! 
+
+use rand_core::{CryptoRng, RngCore};
+
+use nanos_sdk::buttons::ButtonEvent;
+use nanos_ui::{
+    bagls::*,
+    layout::{Draw, Layout, Location, StringPlace},
+    screen_util,
+};
+
+use ledger_mob_core::{
+    engine::{Driver, Engine},
+    apdu::tx::{FogId, FOG_IDS},
+};
+
+use super::{clear_screen, UiResult};
+
+/// [Settings] page, at the moment this only provides Fog configuration
+#[derive(PartialEq, Clone, Debug)]
+pub struct Settings {
+    fog_id_index: usize,
+}
+
+impl Settings {
+    pub fn new(fog_id: FogId) -> Self {
+        let fog_id_index = fog_id as usize;
+        Self{
+            fog_id_index
+        }
+    }
+
+    pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<FogId> {
+        match btn {
+            // Exit on both buttons pressed/released
+            ButtonEvent::BothButtonsRelease => UiResult::Exit(FOG_IDS[self.fog_id_index]),
+
+            // Otherwise move through fogs
+            ButtonEvent::LeftButtonRelease if self.fog_id_index > 0 => {
+                self.fog_id_index -= 1;
+                UiResult::Update
+            },
+            ButtonEvent::RightButtonRelease if self.fog_id_index < 4 => {
+                self.fog_id_index += 1;
+                UiResult::Update
+            },
+
+            // Otherwise, no change
+            _ => UiResult::None,
+        }
+    }
+
+    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, _engine: &Engine<D, R>) {
+        // Clear screen
+        clear_screen();
+
+        // Show arrows
+        if self.fog_id_index > 0 {
+            LEFT_ARROW.shift_v(0).display();
+        }
+        if self.fog_id_index < 4 {
+            RIGHT_ARROW.shift_v(0).display();
+        }
+
+        // Resolve index to fog ID and string
+        let fog = FOG_IDS[self.fog_id_index];
+        let name = fog_name(fog);
+
+        // Display current selection
+        "Fog ID".place(Location::Custom(8), Layout::Centered, false);
+        name.place(Location::Custom(26), Layout::Centered, false);
+
+        // Update screen
+        screen_util::screen_update();
+    }
+}
+
+/// Resolve fog_id to string for display
+fn fog_name(fog_id: FogId) -> &'static str {
+    match fog_id {
+        FogId::None => "None",
+        FogId::MobMain => "MobileCoin MainNet",
+        FogId::MobTest => "MobileCoin TestNet",
+        FogId::SignalMain => "Signal MainNet",
+        FogId::SignalTest => "Signal TestNet",
+    }
+}

--- a/fw/src/ui/settings.rs
+++ b/fw/src/ui/settings.rs
@@ -39,7 +39,7 @@ impl Settings {
                 self.fog_id_index -= 1;
                 UiResult::Update
             }
-            ButtonEvent::RightButtonRelease if self.fog_id_index < 4 => {
+            ButtonEvent::RightButtonRelease if self.fog_id_index < FOG_IDS.len() - 1 => {
                 self.fog_id_index += 1;
                 UiResult::Update
             }
@@ -57,7 +57,7 @@ impl Settings {
         if self.fog_id_index > 0 {
             LEFT_ARROW.shift_v(0).display();
         }
-        if self.fog_id_index < 4 {
+        if self.fog_id_index < FOG_IDS.len() - 1 {
             RIGHT_ARROW.shift_v(0).display();
         }
 

--- a/fw/src/ui/settings.rs
+++ b/fw/src/ui/settings.rs
@@ -1,5 +1,5 @@
 //! Settings page for application UI
-//! 
+//!
 
 use rand_core::{CryptoRng, RngCore};
 
@@ -11,8 +11,8 @@ use nanos_ui::{
 };
 
 use ledger_mob_core::{
-    engine::{Driver, Engine},
     apdu::tx::{FogId, FOG_IDS},
+    engine::{Driver, Engine},
 };
 
 use super::{clear_screen, UiResult};
@@ -26,9 +26,7 @@ pub struct Settings {
 impl Settings {
     pub fn new(fog_id: FogId) -> Self {
         let fog_id_index = fog_id as usize;
-        Self{
-            fog_id_index
-        }
+        Self { fog_id_index }
     }
 
     pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<FogId> {
@@ -40,11 +38,11 @@ impl Settings {
             ButtonEvent::LeftButtonRelease if self.fog_id_index > 0 => {
                 self.fog_id_index -= 1;
                 UiResult::Update
-            },
+            }
             ButtonEvent::RightButtonRelease if self.fog_id_index < 4 => {
                 self.fog_id_index += 1;
                 UiResult::Update
-            },
+            }
 
             // Otherwise, no change
             _ => UiResult::None,


### PR DESCRIPTION
this changes the b58 encoded address displayed on the device, and defaults to the mobilecoin mainnet fog. 

NVM backed persistence is gated behind the `nvm` feature due to crashes on both the nanosplus and speculos (under investigation), so for the moment this does not persist between app launches.

resolves #42 