### PR TITLE
fix engine ident function states

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -270,7 +270,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
             // Request identity proof
             #[cfg(feature = "ident")]
             (
-                State::Init,
+                State::Init | State::Ident(_),
                 Event::IdentSign {
                     ident_index,
                     ident_uri,
@@ -295,6 +295,8 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
             #[cfg(feature = "ident")]
             (State::Ident(s), Event::IdentGet) => {
                 let r = self.get_signed_ident(s);
+
+                self.state = State::Init;
 
                 // Return result
                 return r;


### PR DESCRIPTION
allow new identity signing requests from both the init and signed states and revert to signed state following completed ident request.

cc. @holtzman 