### PR TITLE
swap from exit to pin validation on timeout

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -520,6 +520,11 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
         self.unlocked = true;
     }
 
+    /// Lock the engine (requires approval for key requests and scanning)
+    pub fn lock(&mut self) {
+        self.unlocked = false;
+    }
+
     /// Approve a pending transaction (advances state to `State::Ready`)
     pub fn approve(&mut self) {
         if let State::Pending = self.state {

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -1302,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "nanos_sdk"
 version = "0.2.1"
-source = "git+https://github.com/LedgerHQ/ledger-nanos-sdk?rev=master#4d9bfc6183d94cee6edb239c39286be3825cc179"
+source = "git+https://github.com//LedgerHQ/ledger-nanos-sdk.git?branch=master#4d9bfc6183d94cee6edb239c39286be3825cc179"
 dependencies = [
  "cc",
  "num-traits",

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -127,4 +127,4 @@ mc-transaction-summary = { path ="../vendor/mob/transaction/summary" }
 # patch nanos_sdk so nanos_ui uses the same version
 # hack to avoid cargo#5478 https://github.com/rust-lang/cargo/issues/5478
 [patch."https://github.com/LedgerHQ/ledger-nanos-sdk"]
-nanos_sdk = { git = "https://github.com/LedgerHQ/ledger-nanos-sdk?rev=master" }
+nanos_sdk = { git = "https://github.com//LedgerHQ/ledger-nanos-sdk.git", branch = "master" }

--- a/fw/build.rs
+++ b/fw/build.rs
@@ -55,11 +55,13 @@ fn generate_manifest(target: &str, version: &str) -> anyhow::Result<()> {
 
     // Set flags depending on target:
     // For Nano X, need to enable access to `os_setting_get`.
-    // This will not be necessary anymore in a future upgrade.
-    tmpl = match target {
-        "nanox" => tmpl.replace("FLAGS", "0x200"),
-        _ => tmpl.replace("FLAGS", "0"),
+    // This will not be necessary in a future upgrade.
+    // For all platforms allow global pin request.
+    let flags = match target {
+        "nanox" => 0x240,
+        _ => 0x040,
     };
+    tmpl = tmpl.replace("FLAGS", &format!("0x{flags:04x}"));
 
     // Replace manifest components
     tmpl = tmpl.replace("FW", "ledger-mob-fw.hex");

--- a/fw/src/platform.rs
+++ b/fw/src/platform.rs
@@ -10,6 +10,7 @@ use ledger_proto::{apdus::DeviceInfoResp, ApduError};
 use nanos_sdk::{
     bindings::{os_perso_derive_node_with_seed_key, HDW_ED25519_SLIP10},
     ecc,
+    uxapp::UxEvent,
 };
 #[cfg(feature = "nvm")]
 use nanos_sdk::{
@@ -136,16 +137,9 @@ pub(crate) mod allocator {
     }
 }
 
-/// Timeout and request pin validation to unlock
-// TODO: replace app exit with this behaviour
-// TODO: timeout should also clear app auth flag for key operations
-#[cfg(nyet)]
-fn request_pin_validation() {
-    let mut params = nanos_sdk::bindings::bolos_ux_params_t::default();
-    params.ux_id = nanos_sdk::bindings::BOLOS_UX_VALIDATE_PIN;
-    unsafe {
-        nanos_sdk::bindings::os_ux(&params as *mut nanos_sdk::bindings::bolos_ux_params_t);
-    }
+/// Blocking request for pin validation to unlock
+pub fn request_pin_validation() {
+    UxEvent::ValidatePIN.request();
 }
 
 pub fn fetch_encode_device_info(buff: &mut [u8]) -> Result<usize, ApduError> {

--- a/fw/src/ui/progress.rs
+++ b/fw/src/ui/progress.rs
@@ -49,11 +49,7 @@ impl Progress {
             // Fill progress bar + border
             RectFull::new().width(102).height(10).pos(13, 36).display();
             // Clear null-space based on progress
-            RectFull::new()
-                .width(100)
-                .height(8)
-                .pos(14 as i32, 37)
-                .erase();
+            RectFull::new().width(100).height(8).pos(14_i32, 37).erase();
 
             self.init = true;
         }
@@ -66,11 +62,7 @@ impl Progress {
                 message.place(Location::Custom(16), Layout::Centered, false);
 
                 // Fill progress bar and clear null-space based on progress
-                RectFull::new()
-                    .width(v)
-                    .height(8)
-                    .pos(14 as i32, 37)
-                    .display();
+                RectFull::new().width(v).height(8).pos(14_i32, 37).display();
                 RectFull::new()
                     .width(100 - v)
                     .height(8)


### PR DESCRIPTION
based on an example from the discord, @yhql this seems to crash when the syscall is executed (also, `os_ux_blocking` is declared in rust but has no matching symbol when linking)