### PR TITLE
fix progress bar rendering / flickering

### DIFF
--- a/fw/src/ui/mod.rs
+++ b/fw/src/ui/mod.rs
@@ -131,8 +131,8 @@ impl Ui {
 
     /// Render the [Ui] using the current state
     #[inline(never)]
-    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, engine: &Engine<D, R>) {
-        match &self.state {
+    pub fn render<D: Driver, R: RngCore + CryptoRng>(&mut self, engine: &Engine<D, R>) {
+        match &mut self.state {
             UiState::Menu => self.menu.render(engine),
             UiState::Address(a) => a.render(engine),
             UiState::KeyRequest(a) => a.render(engine),

--- a/fw/src/ui/progress.rs
+++ b/fw/src/ui/progress.rs
@@ -10,8 +10,8 @@ use nanos_ui::{
     screen_util,
 };
 
-use ledger_mob_core::engine::{Driver, Engine, State};
 use super::{clear_screen, UiResult};
+use ledger_mob_core::engine::{Driver, Engine, State};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Progress {
@@ -21,7 +21,7 @@ pub struct Progress {
 impl Progress {
     /// Create a new [Progress] instance
     pub fn new() -> Self {
-        Self{ init: false }
+        Self { init: false }
     }
 
     pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<bool> {

--- a/fw/src/ui/progress.rs
+++ b/fw/src/ui/progress.rs
@@ -11,15 +11,17 @@ use nanos_ui::{
 };
 
 use ledger_mob_core::engine::{Driver, Engine, State};
-
 use super::{clear_screen, UiResult};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Progress;
+pub struct Progress {
+    init: bool,
+}
 
 impl Progress {
+    /// Create a new [Progress] instance
     pub fn new() -> Self {
-        Self
+        Self{ init: false }
     }
 
     pub fn update(&mut self, btn: &ButtonEvent) -> UiResult<bool> {
@@ -31,10 +33,7 @@ impl Progress {
         }
     }
 
-    pub fn render<D: Driver, R: RngCore + CryptoRng>(&self, engine: &Engine<D, R>) {
-        // Clear screen
-        clear_screen();
-
+    pub fn render<D: Driver, R: RngCore + CryptoRng>(&mut self, engine: &Engine<D, R>) {
         // Resolve message based on engine state
         let message = match engine.state() {
             #[cfg(feature = "summary")]
@@ -44,6 +43,21 @@ impl Progress {
             _ => "UNKNOWN",
         };
 
+        // Run full screen setup on first render
+        if !self.init {
+            clear_screen();
+            // Fill progress bar + border
+            RectFull::new().width(102).height(10).pos(13, 36).display();
+            // Clear null-space based on progress
+            RectFull::new()
+                .width(100)
+                .height(8)
+                .pos(14 as i32, 37)
+                .erase();
+
+            self.init = true;
+        }
+
         // Render progress information
         match engine.progress() {
             Some(v) => {
@@ -51,9 +65,12 @@ impl Progress {
 
                 message.place(Location::Custom(16), Layout::Centered, false);
 
-                // Fill progress bar + border
-                RectFull::new().width(102).height(10).pos(13, 36).display();
-                // Clear null-space based on progress
+                // Fill progress bar and clear null-space based on progress
+                RectFull::new()
+                    .width(v)
+                    .height(8)
+                    .pos(14 as i32, 37)
+                    .display();
                 RectFull::new()
                     .width(100 - v)
                     .height(8)


### PR DESCRIPTION
progress bar render now only clears the screen on the first call, resolves flickering when progress bar updates.

Co-authored-by: Henry Holtzman <henry@mobilecoin.com>

cc. @holtzman 