### PR TITLE
add support for miri-based testing of functionality using out-pointers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.4",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -1555,7 +1555,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.4",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -4101,9 +4101,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,14 @@ clippy-fix:
 	cargo clippy --fix --allow-dirty -p ledger-mob -p ledger-mob-apdu -p ledger-mob-core -p ledger-mob-tests --no-deps -- -D warnings
 	cd fw && cargo clippy --fix --target nanosplus --allow-dirty -p ledger-mob-fw --no-deps -- -D warnings
 
+# Run MIRI checks
+# Notes:
+#   - this requires a patched `mc-crypto-hashes` to disable `simd`
+#   - `cargo clean` must be run to clear non-miri objects
+#   - only specific tests with miri support are enabled
+miri:
+	cd core && cargo miri nextest run --no-default-features --features alloc,mlsag,ident,memo,summary -j4 -- miri_function tx_summary ring_sign test_sign
+
 clean:
 	rm -rf target fw/target
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ A top level [Makefile](Makefile) exposes common functions for building / testing
 - `make nanosplus-load` to build firmware and load onto a `nanosplus` device (it is not possible to sideload onto the `nanox`)
 - `make nanosplus-test` or `make nanox-test` to run integration tests via the simulator
 - `make lint` to check `cargo fmt` and `cargo clippy` lints
+- `make miri` to run miri tests over out-pointer based functions (extremely slow)  
+  **This requires `cargo-nextest` as well as disabling the `blake2/simd` feature in `vendor/mobilecoin/crypto/hashes/cargo.toml`**
 
 For more detail you might like to look at [`.github/workflows/rust.yml`](.github/workflows/rust.yml)
 

--- a/core/src/engine/function.rs
+++ b/core/src/engine/function.rs
@@ -245,3 +245,91 @@ impl Function {
         self.inner = FunctionType::None;
     }
 }
+
+#[cfg(test)]
+mod test {
+    use mc_core::account::{Account, PublicSubaddress};
+    use mc_crypto_keys::{RistrettoPrivate, RistrettoPublic};
+    use mc_transaction_types::BlockVersion;
+    use mc_util_from_random::FromRandom;
+    use rand::random;
+    use rand_core::OsRng;
+
+    use super::Function;
+
+    // Set function container to ident mode
+    fn ident_init(f: &mut Function) {
+        f.ident_init(0, "test.lol", &random::<[u8; 32]>()).unwrap();
+    }
+
+    // Set function container to summary generator mode
+    fn summary_init(f: &mut Function) {
+        let account = Account::new(
+            RistrettoPrivate::from_random(&mut OsRng {}).into(),
+            RistrettoPrivate::from_random(&mut OsRng {}).into(),
+        );
+
+        let change_view_private = RistrettoPrivate::from_random(&mut OsRng {});
+        let change_spend_private = RistrettoPrivate::from_random(&mut OsRng {});
+        let change = PublicSubaddress {
+            view_public: RistrettoPublic::from(&change_view_private).into(),
+            spend_public: RistrettoPublic::from(&change_spend_private).into(),
+        };
+
+        f.summarizer_init(
+            &[0u8; 32],
+            BlockVersion::THREE,
+            3,
+            2,
+            account.view_private_key(),
+            &change,
+        );
+    }
+
+    // Set function container to ring signing mode
+    fn ring_init(f: &mut Function) {
+        let account = Account::new(
+            RistrettoPrivate::from_random(&mut OsRng {}).into(),
+            RistrettoPrivate::from_random(&mut OsRng {}).into(),
+        );
+
+        let change_spend_private = RistrettoPrivate::from_random(&mut OsRng {});
+
+        let onetime_private_key = RistrettoPrivate::from_random(&mut OsRng {});
+
+        f.ring_signer_init(
+            11,
+            3,
+            account.view_private_key(),
+            &change_spend_private.into(),
+            random(),
+            &random::<[u8; 32]>(),
+            2,
+            Some(onetime_private_key.into()),
+        )
+        .unwrap();
+    }
+
+    fn clear(f: &mut Function) {
+        f.clear();
+    }
+
+    /// Miri test for function init / state changes
+    #[test]
+    fn miri_function_states() {
+        let mut f = Function::new();
+
+        // Collect state transition functions
+        let states = &[ident_init, summary_init, ring_init, clear];
+
+        // Iterate through possible state transitions
+        for i in 0..states.len() {
+            for j in 0..states.len() {
+                // Call first state
+                states[i](&mut f);
+                // Call next state
+                states[j](&mut f);
+            }
+        }
+    }
+}

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -942,6 +942,8 @@ fn compute_ring_progress(current: usize, ring: usize, total_rings: usize) -> usi
 mod test {
     extern crate std;
 
+    use core::mem::MaybeUninit;
+
     use rand_core::OsRng;
     use strum::IntoEnumIterator;
 
@@ -1126,7 +1128,12 @@ mod test {
         let params =
             RingMLSAGParameters::random(&account, RING_SIZE - 1, pseudo_output_blinding, &mut rng);
 
-        let mut engine = Engine::new_with_rng(drv, rng);
+        // Setup engine
+        let mut e = MaybeUninit::uninit();
+        let mut engine = unsafe {
+            Engine::init(e.as_mut_ptr(), drv, rng);
+            e.assume_init()
+        };
 
         // Initialise new transaction
         let r = engine

--- a/core/src/engine/ring.rs
+++ b/core/src/engine/ring.rs
@@ -77,7 +77,6 @@ pub struct RingSigner {
 
     /// Counter for fetched responses (used for progress tracking)
     fetch_count: usize,
-    //responses: [CurveScalar; RESP_SIZE],
 }
 
 /// Ring blindings container
@@ -112,7 +111,6 @@ impl RingSigner {
             blindings: None,
             ring_ctx: None,
             fetch_count: 0,
-            //responses: [CurveScalar::from(Scalar::ZERO); RESP_SIZE],
         })
     }
 
@@ -338,8 +336,7 @@ impl RingSigner {
             blinding: &blindings.blinding,
             output_blinding: &blindings.output_blinding,
             generator: &self.generator,
-            // TODO: is this important..?
-            check_value_is_preserved: false,
+            check_value_is_preserved: true,
         };
 
         // Setup response storage, this _must_ be ring_size * 2 or init will fail

--- a/core/src/helpers/mod.rs
+++ b/core/src/helpers/mod.rs
@@ -267,8 +267,6 @@ mod test {
             // Create random account without fog info
             let a = AccountKey::random(&mut OsRng {});
 
-            println!("A: {a:?}");
-
             // Test short address hashing
             let h1 = ShortAddressHash::from(&a.default_subaddress());
             let h2 = digest_public_address(a.default_subaddress(), "", &[]);

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -1727,9 +1727,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
-version = "0.9.4"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
adds `make miri` which runs miri tests on `core` functions that use out-pointers. requires `cargo-nextest` and patching the vendored `mc-crypto-hashes` to disable `simd` (and takes -forever- to run, so is not a reasonable candidate for CI).

also reverts a transmute trick to save on stack frame use that miri was unhappy with, though this is _valid_ i am not sure how to convince miri of such, and we currently have the stack headroom for this to be an acceptable compromise (tested on the physical nanosplus).