### PR TITLE
remove unneeded error state on ident failure 

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -296,6 +296,8 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
             (State::Ident(s), Event::IdentGet) => {
                 let r = self.get_signed_ident(s);
 
+                // Reset engine state
+                self.function.clear();
                 self.state = State::Init;
 
                 // Return result
@@ -619,7 +621,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
         }
     }
 
-    /// Approve or deny a pending identity request
+    /// Approve or deny a pending identity request, updating the [IdentState]
     #[cfg(feature = "ident")]
     pub fn ident_approve(&mut self, approve: bool) {
         if let State::Ident(IdentState::Pending) = self.state {
@@ -639,7 +641,6 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
         let ident = match self.function.ident_ref() {
             Some(v) => v,
             None => {
-                self.state = State::Error;
                 return Err(Error::InvalidState);
             }
         };
@@ -655,13 +656,7 @@ impl<DRV: Driver, RNG: CryptoRngCore> Engine<DRV, RNG> {
         // Compute identity object
         let path = ident.path();
         let private_key = self.drv.slip10_derive_ed25519(&path);
-        let r = ident.compute(&private_key);
-
-        // Reset engine state
-        self.function.clear();
-        self.state = State::Init;
-
-        r
+        ident.compute(&private_key)
     }
 
     // Sign the provided memo, returning an `Output::MemoHmac` on success


### PR DESCRIPTION
as it's a one-off operation (rather than a streaming one) we do not need to persist an error on the device.