### PR TITLE
improve testing of RNG syscalls

### DIFF
--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "quote",
  "rand_core",
  "rlibc",
+ "rngcheck",
  "strum",
  "x25519-dalek",
 ]
@@ -1019,6 +1020,12 @@ name = "libm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "link-cplusplus"
@@ -1397,7 +1404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
  "cfg-if",
- "libm",
+ "libm 0.1.4",
 ]
 
 [[package]]
@@ -1609,6 +1616,15 @@ name = "rlibc"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
+
+[[package]]
+name = "rngcheck"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e09ae530166eb0ff7c6c10cea755f2f80d0899f1a3b1899a319c83a346b5203"
+dependencies = [
+ "libm 0.2.7",
+]
 
 [[package]]
 name = "rustc_version"

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -49,6 +49,7 @@ hex_fmt = { version = "0.3.0", default_features = false }
 encdec = { version = "0.9.0", default_features = false }
 emstr = { version = "0.2.0", default_features = false }
 heapless = "0.7.16"
+rngcheck = "0.1.1"
 
 mc-core = { version = "4.1.0-pre0", default-features = false }
 ledger-mob-core = { path = "../core", default_features = false }
@@ -57,7 +58,6 @@ curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }
 ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
 x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
 
-
 libc = "0.2.140"
 rlibc = "1.0.0"
 embedded-alloc = { version = "0.5.0", optional = true }
@@ -65,7 +65,6 @@ critical-section = { version = "1.1.1", optional = true }
 
 # used by bulletproofs-og, no_cc feature required for cross compilation
 clear_on_drop = { version = "0.2", default-features = false, features = [ "no_cc" ] }
-
 
 [build-dependencies]
 image = "0.24.3"

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -548,10 +548,7 @@ fn platform_tests(comm: &mut io::Comm) {
     clear_screen();
 
     // Ensure RNG is operating as expected
-    let mut b = [0xFE; 32];
-    LedgerRng {}.fill_bytes(&mut b);
-
-    if b == [0xFE; 32] || b == [0x00; 32] || b[0] == 0xFE && b[31] == 0xFE {
+    if let Err(_e) = test_rng() {
         "ERROR".place(Location::Top, Layout::Centered, true);
         "RNG UNAVAILABLE".place(Location::Middle, Layout::Centered, false);
         "EXIT?".place(Location::Bottom, Layout::Centered, false);


### PR DESCRIPTION
the normal function of the RNG is critical to the operation of the app, while bolos function calls in the past have moved resulting in failures when accessing the RNG.

to mitigate this risk we run some simple RNG tests at initialisation time, not to prove the RNG is -correct- but to ensure that calls through the OS behave as expected.

platform RNG tests now check both `LedgerRng` and injected `OsRng` instances using nist monobit and block frequency statistical tests.