### PR TITLE
WIP: enable integer overflow checks for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 cargo-features = ["per-package-target"]
 
 [workspace]
+resolver = "2"
 
 members = [
     "apdu",

--- a/fw/.cargo/config.toml
+++ b/fw/.cargo/config.toml
@@ -9,10 +9,8 @@ runner = "speculos.py --model nanox --display qt -a 5 --apdu-port 1237 --zoom 2"
 target = "nanosplus"
 rustflags = [
     "-Z", "emit-stack-sizes",
-    "-C", "link-args=-Map=/tmp/ledger-mob.map",
     '--cfg=curve25519_dalek_bits="32"'
 ]
-
 
 [unstable]
 build-std = [ "core", "compiler_builtins", "alloc" ]

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -1,5 +1,8 @@
 
-cargo-features = ["per-package-target"]
+cargo-features = ["per-package-target", "profile-rustflags"]
+
+[unstable]
+profile-rustflags = true
 
 [package]
 name = "ledger-mob-fw"
@@ -83,10 +86,12 @@ required-features = [ "applet" ]
 [profile.dev]
 #codegen-units = 1
 panic = "abort"
-debug = true
+debug = 2
 strip = "none"
 split-debuginfo = "off"
 opt-level = 'z'
+lto = 'fat'
+overflow-checks = true
 
 [profile.release]
 codegen-units = 1
@@ -96,14 +101,17 @@ strip = "none"
 split-debuginfo = "off"
 opt-level = 'z'
 lto = 'fat'
+overflow-checks = true
 
-# Rust/cargo bug precludes integer overflow checks
-# when using LTO, see:
-# https://github.com/rust-lang/rust/issues/108853
-#overflow-checks = true
+# Disable overflow checks for compiler_builtins
+# See:
+#  - https://github.com/rust-lang/cargo/issues/10118
+#  - https://github.com/rust-lang/rust/issues/108853
+[profile.release.package.compiler_builtins]
+debug-assertions = false
+overflow-checks = false
 
 [patch.crates-io]
-
 
 curve25519-dalek = { git = "https://github.com/dalek-cryptography/curve25519-dalek", rev = "99c0520aa79401b69fb51d38172cd58c6a256cfb" }
 ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "2931c688eb11341a1145e257bc41d8ecbe36277c" }

--- a/fw/rust-toolchain
+++ b/fw/rust-toolchain
@@ -1,1 +1,3 @@
-rust-toolchain
+[toolchain]
+channel = "nightly-2023-01-04"
+components = [ "rustfmt", "clippy", "rust-src" ]


### PR DESCRIPTION
integer overflow checks would be nice to have, however, these cause summary and ring operations to fail with what is either a mishandled panic or a stack related regression, resulting in an extremely cursed series of observations:

- fault only exists in hw, this is not reproducible in speculos or local tests using -exactly the same- mnemonics and test vectors
  (if an integer overflow panic was the cause i would expect to see the same fault in speculos?)
-  USB transport reports zero length response / missing HID header
  (something has gone wrong at the OS level when attempting to respond, for example, attempting to panic while exceeding the stack pointer limitation?)
- app continues to run and respond to user inputs following this failure
  (a panic _should_ result in an abort, but this could be a failure of the nanos_sdk panic handler?)
  
reproduce by:
- configuring a nanosplus with the test mnemonic (`duck diamond ...`) to match the test vectors
- building and loading the firmware from this branch with `make nanosplus-load`
- running the transaction test with `cargo run --bin ledger-mob-tests -- --target hid tx --input tests/vectors/tx3.json`

