### PR TITLE
Force re-draw on pin entry

### DIFF
--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -184,8 +184,9 @@ extern "C" fn sample_main() {
                     // Execute lock syscall (blocks on pin entry)
                     request_pin_validation();
 
-                    // Reset timeout on re-entry
+                    // Reset timeout and redraw on re-entry
                     lock_timeout = ticks.wrapping_add(LOCK_TIMEOUT_S * TICKS_PER_S);
+                    redraw = true;
                 }
             }
         };


### PR DESCRIPTION
fixes delay between pin unlock and menu re-rendering