### PR TITLE
update to mobilecoin v5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2282,14 +2282,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-api"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "bs58",
  "cargo-emit",
@@ -2310,13 +2310,14 @@ dependencies = [
  "mc-util-build-script",
  "mc-util-repr-bytes",
  "mc-util-serial",
+ "mc-util-uri",
  "mc-watcher-api",
  "protobuf",
 ]
 
 [[package]]
 name = "mc-attest-verifier-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -2330,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "mc-blockchain-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "displaydoc",
  "hex_fmt",
@@ -2353,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "mc-common"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -2388,7 +2389,7 @@ dependencies = [
 
 [[package]]
 name = "mc-consensus-scp-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-common",
  "mc-crypto-digestible",
@@ -2400,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2418,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "2.0.0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -2429,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-box"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "aead",
  "digest 0.10.6",
@@ -2443,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -2456,7 +2457,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2465,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -2474,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "blake2",
  "digest 0.10.6",
@@ -2483,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "base64 0.21.0",
  "curve25519-dalek",
@@ -2512,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "hmac",
  "mc-crypto-keys",
@@ -2521,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-multisig"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-digestible",
  "mc-crypto-keys",
@@ -2531,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2553,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature-signer"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -2573,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-keys",
 ]
@@ -2604,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-core"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "aes 0.8.2",
  "bulletproofs-og",
@@ -2642,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-extra"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -2675,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-signer"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2704,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-summary"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -2724,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "crc",
  "displaydoc",
@@ -2742,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-grpc"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-util-build-script",
  "protoc-grpcio",
@@ -2750,14 +2751,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-build-info"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "cargo-emit",
 ]
 
 [[package]]
 name = "mc-util-build-script"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "cargo-emit",
  "displaydoc",
@@ -2768,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-encodings"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "base64 0.21.0",
  "displaydoc",
@@ -2779,14 +2780,18 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
+name = "mc-util-host-cert"
+version = "5.0.8"
+
+[[package]]
 name = "mc-util-logger-macros"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2795,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "generic-array",
  "hex_fmt",
@@ -2805,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-serial"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "prost",
  "serde",
@@ -2815,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-test-helper"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2826,11 +2831,26 @@ dependencies = [
 
 [[package]]
 name = "mc-util-u64-ratio"
-version = "4.1.0-pre0"
+version = "5.0.8"
+
+[[package]]
+name = "mc-util-uri"
+version = "5.0.8"
+dependencies = [
+ "base64 0.21.0",
+ "displaydoc",
+ "hex",
+ "mc-common",
+ "mc-crypto-keys",
+ "mc-util-host-cert",
+ "percent-encoding",
+ "serde",
+ "url",
+]
 
 [[package]]
 name = "mc-util-vec-map"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -2838,14 +2858,14 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "mc-watcher-api"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "displaydoc",
  "serde",

--- a/apdu/Cargo.toml
+++ b/apdu/Cargo.toml
@@ -33,12 +33,12 @@ sha2 = { version = "0.10.6", default_features = false }
 
 ledger-proto = { version = "0.1.0", default_features = false }
 
-mc-core = { version = "4.1.0-pre0", default_features = false, features = [ "internals" ] }
-mc-crypto-digestible = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-ring-signature = { version = "4.1.0-pre0", default_features = false }
-mc-transaction-types = { version = "4.1.0-pre0", default_features = false }
-mc-util-from-random = { version = "4.1.0-pre0", default_features = false }
+mc-core = { version = "5", default_features = false, features = [ "internals" ] }
+mc-crypto-digestible = { version = "5", default_features = false }
+mc-crypto-keys = { version = "5", default_features = false }
+mc-crypto-ring-signature = { version = "5", default_features = false }
+mc-transaction-types = { version = "5", default_features = false }
+mc-util-from-random = { version = "5", default_features = false }
 
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -70,16 +70,16 @@ ledger-mob-apdu = { path = "../apdu", default_features = false }
 
 ledger-proto = { version = "0.1.0", default_features = false }
 
-mc-core = { version = "4.1.0-pre0", default_features = false, features = [ "internals" ] }
-mc-crypto-digestible = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-hashes = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-ring-signature = { version = "4.1.0-pre0", optional = true, default_features = false, features = [ "internals" ] }
-mc-crypto-memo-mac = { version = "4.1.0-pre0", optional = true, default_features = false }
-mc-fog-sig-authority = { version = "4.1.0-pre0", default_features = false }
-mc-transaction-types = { version = "4.1.0-pre0", default_features = false }
-mc-transaction-summary = { version = "4.1.0-pre0", default_features = false, optional = true }
-mc-util-from-random = { version = "4.1.0-pre0", default_features = false }
+mc-core = { version = "5", default_features = false, features = [ "internals" ] }
+mc-crypto-digestible = { version = "5", default_features = false }
+mc-crypto-keys = { version = "5", default_features = false }
+mc-crypto-hashes = { version = "5", default_features = false }
+mc-crypto-ring-signature = { version = "5", optional = true, default_features = false, features = [ "internals" ] }
+mc-crypto-memo-mac = { version = "5", optional = true, default_features = false }
+mc-fog-sig-authority = { version = "5", default_features = false }
+mc-transaction-types = { version = "5", default_features = false }
+mc-transaction-summary = { version = "5", default_features = false, optional = true }
+mc-util-from-random = { version = "5", default_features = false }
 
 
 # used by bulletproofs-og, no_cc feature required for cross compilation
@@ -103,8 +103,8 @@ tokio = { version = "1.20.1", features = [ "full" ] }
 async-trait = "0.1.57"
 
 
-mc-account-keys = { version = "4.1.0-pre0", default_features = false, features = [ "serde" ] }
-mc-api = { version = "4.1.0-pre0", default_features = false }
+mc-account-keys = { version = "5", default_features = false, features = [ "serde" ] }
+mc-api = { version = "5", default_features = false }
 mc-util-test-helper = { path = "../vendor/mob/util/test-helper", default_features = false }
 ledger-mob-tests = { path = "../tests", default_features = false }
 ledger-lib = { version = "0.1.0", default_features =  false }

--- a/core/src/engine/summary.rs
+++ b/core/src/engine/summary.rs
@@ -327,6 +327,11 @@ impl<const MAX_RECORDS: usize> Summarizer<MAX_RECORDS> {
         // Finalise verification report
         verifier.finalize(fee, tombstone_block, digest, &mut self.report);
 
+        // Elide SCIs from totals for rendering
+        // TODO: we may wish to revisit this when SCIs are widely used
+        self.report.elide_swap_totals();
+
+        // Set complete state
         self.state = SummaryState::Complete;
 
         // Return message and report

--- a/fw/Cargo.lock
+++ b/fw/Cargo.lock
@@ -1069,14 +1069,14 @@ dependencies = [
 
 [[package]]
 name = "mc-account-keys-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-core"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "mc-core-types"
-version = "2.0.0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "mc-crypto-keys",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "cfg-if",
  "curve25519-dalek",
@@ -1114,7 +1114,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-derive"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-digestible-signature"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-digestible",
  "schnorrkel-og",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-hashes"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "blake2",
  "digest",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-keys"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "base64",
  "curve25519-dalek",
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-memo-mac"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "hmac",
  "mc-crypto-keys",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "mc-crypto-ring-signature"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "curve25519-dalek",
  "displaydoc",
@@ -1196,14 +1196,14 @@ dependencies = [
 
 [[package]]
 name = "mc-fog-sig-authority"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "mc-crypto-keys",
 ]
 
 [[package]]
 name = "mc-transaction-summary"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "mc-transaction-types"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "crc",
  "displaydoc",
@@ -1237,21 +1237,21 @@ dependencies = [
 
 [[package]]
 name = "mc-util-from-random"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "mc-util-repr-bytes"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "mc-util-vec-map"
-version = "4.1.0-pre0"
+version = "5.0.8"
 dependencies = [
  "displaydoc",
  "heapless",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mc-util-zip-exact"
-version = "4.1.0-pre0"
+version = "5.0.8"
 
 [[package]]
 name = "memoffset"

--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -51,7 +51,7 @@ emstr = { version = "0.2.0", default_features = false }
 heapless = "0.7.16"
 rngcheck = "0.1.1"
 
-mc-core = { version = "4.1.0-pre0", default-features = false }
+mc-core = { version = "5", default-features = false }
 ledger-mob-core = { path = "../core", default_features = false }
 
 curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }

--- a/fw/src/ui/tx_summary_approver.rs
+++ b/fw/src/ui/tx_summary_approver.rs
@@ -254,7 +254,7 @@ impl TxSummaryApprover {
             // Totals
             Total(n) => {
                 // Fetch total information
-                let (token_id, value) = &report.totals[n];
+                let (token_id, _total_kind, value) = &report.totals[n];
 
                 let value_str = fmt_token_val(*value, *token_id, &mut value_buff);
                 let title_str = fmt_page("Total", n, self.num_totals, &mut title_buff);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -45,14 +45,14 @@ ledger-proto = { version = "0.1.0" }
 
 ledger-mob-apdu = { path = "../apdu" }
 
-mc-core = { version = "4.1.0-pre0", features = [ "serde" ] }
-mc-crypto-keys = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-ring-signature = { version = "4.1.0-pre0", default_features = false }
-mc-crypto-ring-signature-signer = { version = "4.1.0-pre0", default_features = false }
-mc-transaction-core = { version = "4.1.0-pre0" }
-mc-transaction-extra = { version = "4.1.0-pre0" }
-mc-transaction-signer = { version = "4.1.0-pre0" }
-mc-transaction-summary = { version = "4.1.0-pre0" }
+mc-core = { version = "5", features = [ "serde" ] }
+mc-crypto-keys = { version = "5", default_features = false }
+mc-crypto-ring-signature = { version = "5", default_features = false }
+mc-crypto-ring-signature-signer = { version = "5", default_features = false }
+mc-transaction-core = { version = "5" }
+mc-transaction-extra = { version = "5" }
+mc-transaction-signer = { version = "5" }
+mc-transaction-summary = { version = "5" }
 
 [dev-dependencies]
 toml = "0.5.9"
@@ -67,10 +67,10 @@ curve25519-dalek = { version = "4.0.0-rc.1", default_features = false }
 x25519-dalek = { version = "2.0.0-pre.2", default_features = false }
 ed25519-dalek = { version = "2.0.0-pre.0", default_features = false }
 
-mc-core = { version = "4.1.0-pre0", features = [ "bip39" ] }
-mc-crypto-keys = { version = "4.1.0-pre0", default-features = false }
-mc-crypto-ring-signature = { version = "4.1.0-pre0", default-features = false }
-mc-util-from-random = { version = "4.1.0-pre0", default-features = false }
+mc-core = { version = "5", features = [ "bip39" ] }
+mc-crypto-keys = { version = "5", default-features = false }
+mc-crypto-ring-signature = { version = "5", default-features = false }
+mc-util-from-random = { version = "5", default-features = false }
 
 [[bin]]
 name = "ledger-mob-cli"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,15 +29,15 @@ serde = "1.0.144"
 serde_json = "1.0.95"
 tiny-bip39 = "1.0"
 
-mc-core = { version = "4.1.0-pre0", features = [ "bip39" ] }
-mc-crypto-keys = { version = "4.1.0-pre0", default-features = false }
-mc-crypto-ring-signature = { version = "4.1.0-pre0", default-features = false, features = [ "internals" ] }
-mc-crypto-memo-mac = { version = "4.1.0-pre0", default-features = false }
-mc-transaction-core = { version = "4.1.0-pre0" }
-mc-transaction-extra = { version = "4.1.0-pre0" }
-mc-transaction-signer = { version = "4.1.0-pre0" }
-mc-transaction-summary = { version = "4.1.0-pre0" }
-mc-util-from-random = { version = "4.1.0-pre0", default-features = false }
+mc-core = { version = "5", features = [ "bip39" ] }
+mc-crypto-keys = { version = "5", default-features = false }
+mc-crypto-ring-signature = { version = "5", default-features = false, features = [ "internals" ] }
+mc-crypto-memo-mac = { version = "5", default-features = false }
+mc-transaction-core = { version = "5" }
+mc-transaction-extra = { version = "5" }
+mc-transaction-signer = { version = "5" }
+mc-transaction-summary = { version = "5" }
+mc-util-from-random = { version = "5", default-features = false }
 
 ledger-mob-apdu = { path = "../apdu" }
 ledger-mob = { path = "../lib", default_features = false }
@@ -63,7 +63,7 @@ tiny-bip39 = "1.0"
 slip10_ed25519 = "0.1.3"
 simplelog = "0.12.1"
 
-mc-util-test-helper = { version = "4.1.0-pre0", default_features = false }
+mc-util-test-helper = { version = "5", default_features = false }
 
 [[bin]]
 name = "ledger-mob-tests"


### PR DESCRIPTION
updates to mobilecoin.git v5.0, using updated transaction report implementation (https://github.com/mobilecoinfoundation/mobilecoin/pull/3316) with patch for ledger required MSRV.

replaces #63 
